### PR TITLE
fix: update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,10 @@ Medusa is an open-source headless commerce engine that enables developers to cre
 
 1. **Setting up the enviroment variables**
 
-    Get your enviroment variables ready:
+    Navigate into your projects directory and get your enviroment variables ready:
 
     ```shell
+    cd nextjs-starter-medusa/
     mv .env.template .env.local
     ```
 
@@ -53,10 +54,9 @@ Medusa is an open-source headless commerce engine that enables developers to cre
 
 3.  **Start developing.**
 
-    Navigate into your projects directory and start it up.
+     You are now ready to start the project up.
 
     ```shell
-    cd nextjs-starter-medusa/
     yarn dev
     ```
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,30 @@
+<p align="center">
+  <a href="https://www.medusa-commerce.com">
+    <img alt="Medusa" src="https://user-images.githubusercontent.com/7554214/129161578-19b83dc8-fac5-4520-bd48-53cba676edd2.png" width="100" />
+  </a>
+</p>
 <h1 align="center">
-  Medusa + Next.js Starter 🚀
+  Medusa Next.js Starter
 </h1>
+<p align="center">
+Medusa is an open-source headless commerce engine that enables developers to create amazing digital commerce experiences.
+</p>
+<p align="center">
+  <a href="https://github.com/medusajs/medusa/blob/master/LICENSE">
+    <img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="Medusa is released under the MIT license." />
+  </a>
+  <a href="https://github.com/medusajs/medusa/blob/master/CONTRIBUTING.md">
+    <img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat" alt="PRs welcome!" />
+  </a>
+  <a href="https://discord.gg/xpCwq3Kfn8">
+    <img src="https://img.shields.io/badge/chat-on%20discord-7289DA.svg" alt="Discord Chat" />
+  </a>
+  <a href="https://twitter.com/intent/follow?screen_name=medusajs">
+    <img src="https://img.shields.io/twitter/follow/medusajs.svg?label=Follow%20@medusajs" alt="Follow @medusajs" />
+  </a>
+</p>
 
-> **Prerequisites**: To use the starter you should have a Medusa server running locally on port 4000. Check out [medusa-starter-default](https://github.com/medusajs/medusa-starter-default) for a quick setup. Note that you need to change `STORE_CORS` in `medusa-config.js` to `http://localhost:3000` when using the Next.js starter.
+> **Prerequisites**: To use the starter you should have a Medusa server running locally on port 9000. Check out [medusa-starter-default](https://github.com/medusajs/medusa-starter-default) for a quick setup. **Note** that you need to change `STORE_CORS` in `medusa-config.js` to `http://localhost:3000` when running the Next.js starter on the default port.
 
 ## Quick start
 


### PR DESCRIPTION
**What**

- Updates to reflect change to BACKEND_URL fallback value
- Emphasizes the need to change the STORE_CORS, when running the starter on the default Next.js port `localhost:3000`
- Adds header from Contentful starter

**Why**
- Feedback from user that he was receiving errors when trying to run the starter while running the medusa-default-starter on port 9000. Change makes it so users has to do as little changes as possible to get up and running with the Next.js + medusa-default-starter setup.