### PR TITLE
fix: getVariantPrices now returns the correct prices

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,9 @@
 module.exports = {
   reactStrictMode: true,
   images: {
-    domains: ["medusa-public-images.s3.eu-west-1.amazonaws.com"],
+    domains: [
+      "medusa-public-images.s3.eu-west-1.amazonaws.com",
+      "static.miinto.net",
+    ],
   },
 };

--- a/utils/prices.js
+++ b/utils/prices.js
@@ -21,11 +21,12 @@ export function getVariantPrice(cart, variant) {
   let taxRate = getTaxRate(cart);
 
   let moneyAmount = variant.prices.find(
-    (p) => p.currency_code.toLowerCase() === cart.currency_code.toLowerCase()
+    (p) =>
+      p.currency_code.toLowerCase() === cart.region.currency_code.toLowerCase()
   );
 
   if (moneyAmount && moneyAmount.amount) {
-    return moneyAmount.amount * (1 + taxRate);
+    return (moneyAmount.amount * (1 + taxRate)) / 100;
   }
 
   return undefined;


### PR DESCRIPTION
**What**
- Fixes getVariantPrices function

**How**
Changed

```js
export function getVariantPrice(cart, variant) {
  let taxRate = getTaxRate(cart);

  let moneyAmount = variant.prices.find(
    (p) =>
      p.currency_code.toLowerCase() === cart.currency_code.toLowerCase()
  );

  if (moneyAmount && moneyAmount.amount) {
    return (moneyAmount.amount * (1 + taxRate));
  }

  return undefined;
}
```

to

```js
export function getVariantPrice(cart, variant) {
  let taxRate = getTaxRate(cart);

  let moneyAmount = variant.prices.find(
    (p) =>
      p.currency_code.toLowerCase() === cart.region.currency_code.toLowerCase()
  );

  if (moneyAmount && moneyAmount.amount) {
    return (moneyAmount.amount * (1 + taxRate)) / 100;
  }

  return undefined;
}
```


