### PR TITLE
fix: support image src with no protocol

### DIFF
--- a/src/modules/products/components/image-gallary/index.tsx
+++ b/src/modules/products/components/image-gallary/index.tsx
@@ -34,7 +34,9 @@ const ImageGallery = ({ images }: ImageGalleryProps) => {
             >
               <span className="sr-only">Go to image {index + 1}</span>
               <Image
-                src={image.url}
+                src={
+                  image.url.startsWith("//") ? `https:${image.url}` : image.url
+                }
                 layout="fill"
                 objectFit="cover"
                 className="absolute inset-0"
@@ -54,7 +56,9 @@ const ImageGallery = ({ images }: ImageGalleryProps) => {
               id={image.id}
             >
               <Image
-                src={image.url}
+                src={
+                  image.url.startsWith("//") ? `https:${image.url}` : image.url
+                }
                 layout="fill"
                 objectFit="cover"
                 priority={index <= 2 ? true : false}

--- a/src/modules/products/components/thumbnail/index.tsx
+++ b/src/modules/products/components/thumbnail/index.tsx
@@ -37,7 +37,7 @@ const ImageOrPlaceholder = ({
 }: Pick<ThumbnailProps, "size"> & { image?: string }) => {
   return image ? (
     <Image
-      src={image}
+    src={image.startsWith("//") ? `https:${image}` : image}
       alt="Thumbnail"
       layout="fill"
       objectFit="cover"


### PR DESCRIPTION
Was having issues with displaying images where all URLs are of the format: `//domain.com/path-to-img`