### PR TITLE
Update starter to auto select country if cart has shipping country set

### DIFF
--- a/src/lib/context/store-context.tsx
+++ b/src/lib/context/store-context.tsx
@@ -106,19 +106,21 @@ export const StoreProvider = ({ children }: StoreProps) => {
     )
   }
 
-  const ensureRegion = (region: Region) => {
+  const ensureRegion = (region: Region, countryCode?: string | null) => {
     if (!IS_SERVER) {
-      const { regionId, countryCode } = getRegion() || {
+      const { regionId, countryCode: defaultCountryCode } = getRegion() || {
         regionId: region.id,
         countryCode: region.countries[0].iso_2,
       }
 
+      const finalCountryCode = countryCode || defaultCountryCode
+
       if (regionId !== region.id) {
-        setRegion(region.id, countryCode)
+        setRegion(region.id, finalCountryCode)
       }
 
-      storeRegion(region.id, countryCode)
-      setCountryCode(countryCode)
+      storeRegion(region.id, finalCountryCode)
+      setCountryCode(finalCountryCode)
     }
   }
 
@@ -154,7 +156,7 @@ export const StoreProvider = ({ children }: StoreProps) => {
         onSuccess: ({ cart }) => {
           setCart(cart)
           storeCart(cart.id)
-          ensureRegion(cart.region)
+          ensureRegion(cart.region, cart.shipping_address?.country_code)
         },
         onError: (error) => {
           if (process.env.NODE_ENV === "development") {
@@ -178,7 +180,7 @@ export const StoreProvider = ({ children }: StoreProps) => {
         onSuccess: ({ cart }) => {
           setCart(cart)
           storeCart(cart.id)
-          ensureRegion(cart.region)
+          ensureRegion(cart.region, cart.shipping_address?.country_code)
         },
         onError: (error) => {
           if (process.env.NODE_ENV === "development") {


### PR DESCRIPTION
## What

When a cart is created, it may return `cart.shipping_address.country_code` if the backend is able to detect the user's country. This change updates the starter to make use of the `cart.shipping_address.country_code`, if there is one, to auto select the country.

Closes: #73

## Why

This is helpful as it reduces friction for end users by reducing the steps they need to take in order to purchase something.

## How

`ensureRegion()` was updated to take in a country code if one was present.

## Testing

This was manually tested by making use of an IP lookup plugin like the [Maxmind IP Lookup plugin](https://www.npmjs.com/package/medusa-plugin-ip-lookup-maxmind), to automatically set the region and country. The following screenshot shows the cart with the shipping address as US and the country selected as US.

<img width="1677" alt="image" src="https://user-images.githubusercontent.com/1477010/197682743-6b80ad7f-dfe8-40a4-800e-753fb10b3a32.png">
