### PR TITLE
Fix modal cutting content issue

### DIFF
--- a/src/modules/common/components/modal/index.tsx
+++ b/src/modules/common/components/modal/index.tsx
@@ -44,7 +44,7 @@ const Modal: React.FC<ModalProps> & {
             >
               <Dialog.Panel
                 className={clsx(
-                  "w-full h-full transform overflow-hidden bg-white p-10 text-left align-middle shadow-xl transition-all max-h-[65vh]",
+                  "flex flex-col justify-start w-full h-full transform overflow-hidden bg-white p-10 text-left align-middle shadow-xl transition-all max-h-[65vh]",
                   {
                     "max-w-md": size === "small",
                     "max-w-xl": size === "medium",
@@ -86,7 +86,7 @@ const Description: React.FC = ({ children }) => {
 }
 
 const Body: React.FC = ({ children }) => {
-  return <div className="h-full">{children}</div>
+  return <div className="flex-1">{children}</div>
 }
 
 const Footer: React.FC = ({ children }) => {


### PR DESCRIPTION
Fixes #77 by using `flex-1` class instead of `h-full`

After changes:
<img width="1242" alt="12-11-2022-at-18-54-08@2x" src="https://user-images.githubusercontent.com/28081510/201476116-1f84feea-8a34-4491-9988-a7146a984c8b.png">
