### PR TITLE
Fix: cart crash on backorders

### DIFF
--- a/src/modules/cart/components/item/index.tsx
+++ b/src/modules/cart/components/item/index.tsx
@@ -35,7 +35,15 @@ const Item = ({ item, region }: ItemProps) => {
             }
             className="max-h-[35px] w-[75px]"
           >
-            {Array.from([...Array(item.variant.inventory_quantity)].keys())
+            {Array.from(
+              [
+                ...Array(
+                  item.variant.inventory_quantity > 0
+                    ? item.variant.inventory_quantity
+                    : 10
+                ),
+              ].keys()
+            )
               .slice(0, 10)
               .map((i) => {
                 const value = i + 1


### PR DESCRIPTION
Closes #42.

If `item.variant.inventory_quantity` is negative, it would mean backordering is on. So, quantity select will have default max of 10 values.