### PR TITLE
Import types from @medusajs/client-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@headlessui/react": "^1.6.1",
     "@hookform/error-message": "^2.0.0",
-    "@medusajs/medusa-js": "1.3.10-dev-1679077162720",
+    "@medusajs/medusa-js": "2.0.0-snapshot-20230320172940",
     "@meilisearch/instant-meilisearch": "^0.7.1",
     "@paypal/paypal-js": "^5.0.6",
     "@paypal/react-paypal-js": "^7.8.1",
@@ -31,7 +31,7 @@
     "@tanstack/react-query": "^4.22.4",
     "clsx": "^1.1.1",
     "lodash": "^4.17.21",
-    "medusa-react": "4.0.4-dev-1679077162720",
+    "medusa-react": "5.0.0-snapshot-20230320172940",
     "next": "^12.2.0",
     "react": "17.0.2",
     "react-country-flag": "^3.0.2",
@@ -43,8 +43,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.17.5",
-    "@medusajs/client-types": "0.1.0-dev-1679077162720",
-    "@medusajs/medusa": "1.7.13-dev-1679077162720",
+    "@medusajs/client-types": "0.2.0-snapshot-20230320172940",
+    "@medusajs/medusa": "2.0.0-snapshot-20230320172940",
     "@types/node": "17.0.21",
     "@types/react": "17.0.40",
     "@types/react-instantsearch-dom": "^6.12.3",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@headlessui/react": "^1.6.1",
     "@hookform/error-message": "^2.0.0",
-    "@medusajs/medusa-js": "^1.3.7",
+    "@medusajs/medusa-js": "1.3.10-dev-1679077162720",
     "@meilisearch/instant-meilisearch": "^0.7.1",
     "@paypal/paypal-js": "^5.0.6",
     "@paypal/react-paypal-js": "^7.8.1",
@@ -31,7 +31,7 @@
     "@tanstack/react-query": "^4.22.4",
     "clsx": "^1.1.1",
     "lodash": "^4.17.21",
-    "medusa-react": "^4.0.4",
+    "medusa-react": "4.0.4-dev-1679077162720",
     "next": "^12.2.0",
     "react": "17.0.2",
     "react-country-flag": "^3.0.2",
@@ -43,7 +43,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.17.5",
-    "@medusajs/medusa": "^1.7.5",
+    "@medusajs/client-types": "0.1.0-dev-1679077162720",
+    "@medusajs/medusa": "1.7.13-dev-1679077162720",
     "@types/node": "17.0.21",
     "@types/react": "17.0.40",
     "@types/react-instantsearch-dom": "^6.12.3",

--- a/src/lib/context/account-context.tsx
+++ b/src/lib/context/account-context.tsx
@@ -1,5 +1,5 @@
 import { medusaClient } from "@lib/config"
-import { Customer } from "@medusajs/medusa"
+import { StoreCustomersRes } from "@medusajs/client-types"
 import { useMutation } from "@tanstack/react-query"
 import { useMeCustomer } from "medusa-react"
 import { useRouter } from "next/router"
@@ -11,7 +11,7 @@ export enum LOGIN_VIEW {
 }
 
 interface AccountContext {
-  customer?: Omit<Customer, "password_hash">
+  customer?: StoreCustomersRes["customer"]
   retrievingCustomer: boolean
   loginView: [LOGIN_VIEW, React.Dispatch<React.SetStateAction<LOGIN_VIEW>>]
   checkSession: () => void

--- a/src/lib/context/checkout-context.tsx
+++ b/src/lib/context/checkout-context.tsx
@@ -1,11 +1,6 @@
 import { medusaClient } from "@lib/config"
 import useToggleState, { StateType } from "@lib/hooks/use-toggle-state"
-import {
-  Address,
-  Cart,
-  Customer,
-  StorePostCartsCartReq,
-} from "@medusajs/medusa"
+import { Address, Cart, Customer, StorePostCartsCartReq } from "@medusajs/client-types"
 import Wrapper from "@modules/checkout/components/payment-wrapper"
 import { isEqual } from "lodash"
 import {
@@ -89,7 +84,7 @@ export const CheckoutProvider = ({ children }: CheckoutProviderProps) => {
   } = useSetPaymentSession(cart?.id!)
 
   const { mutate: updateCart, isLoading: updatingCart } = useUpdateCart(
-    cart?.id!
+    cart?.id!,
   )
 
   const { shipping_options } = useCartShippingOptions(cart?.id!, {
@@ -105,7 +100,7 @@ export const CheckoutProvider = ({ children }: CheckoutProviderProps) => {
   const sameAsBilling = useToggleState(
     cart?.billing_address && cart?.shipping_address
       ? isEqual(cart.billing_address, cart.shipping_address)
-      : true
+      : true,
   )
 
   /**
@@ -188,7 +183,7 @@ export const CheckoutProvider = ({ children }: CheckoutProviderProps) => {
         { option_id: soId },
         {
           onSuccess: ({ cart }) => setCart(cart),
-        }
+        },
       )
     }
   }
@@ -234,7 +229,7 @@ export const CheckoutProvider = ({ children }: CheckoutProviderProps) => {
           onSuccess: ({ cart }) => {
             setCart(cart)
           },
-        }
+        },
       )
     }
   }
@@ -270,7 +265,7 @@ export const CheckoutProvider = ({ children }: CheckoutProviderProps) => {
   const validateRegion = (countryCode: string) => {
     if (regions && cart) {
       const region = regions.find((r) =>
-        r.countries.map((c) => c.iso_2).includes(countryCode)
+        r.countries.map((c) => c.iso_2).includes(countryCode),
       )
 
       if (region && region.id !== cart.region.id) {
@@ -349,7 +344,7 @@ export const useCheckout = () => {
   const form = useFormContext<CheckoutFormValues>()
   if (context === null) {
     throw new Error(
-      "useProductActionContext must be used within a ProductActionProvider"
+      "useProductActionContext must be used within a ProductActionProvider",
     )
   }
   return { ...context, ...form }
@@ -364,7 +359,7 @@ export const useCheckout = () => {
 const mapFormValues = (
   customer?: Omit<Customer, "password_hash">,
   cart?: Omit<Cart, "refundable_amount" | "refunded_total">,
-  currentCountry?: string
+  currentCountry?: string,
 ): CheckoutFormValues => {
   const customerShippingAddress = customer?.shipping_addresses?.[0]
   const customerBillingAddress = customer?.billing_address

--- a/src/lib/context/checkout-context.tsx
+++ b/src/lib/context/checkout-context.tsx
@@ -1,6 +1,11 @@
 import { medusaClient } from "@lib/config"
 import useToggleState, { StateType } from "@lib/hooks/use-toggle-state"
-import { Address, Cart, Customer, StorePostCartsCartReq } from "@medusajs/client-types"
+import {
+  Address,
+  Cart,
+  Customer,
+  StorePostCartsCartReq,
+} from "@medusajs/client-types"
 import Wrapper from "@modules/checkout/components/payment-wrapper"
 import { isEqual } from "lodash"
 import {
@@ -84,7 +89,7 @@ export const CheckoutProvider = ({ children }: CheckoutProviderProps) => {
   } = useSetPaymentSession(cart?.id!)
 
   const { mutate: updateCart, isLoading: updatingCart } = useUpdateCart(
-    cart?.id!,
+    cart?.id!
   )
 
   const { shipping_options } = useCartShippingOptions(cart?.id!, {
@@ -100,7 +105,7 @@ export const CheckoutProvider = ({ children }: CheckoutProviderProps) => {
   const sameAsBilling = useToggleState(
     cart?.billing_address && cart?.shipping_address
       ? isEqual(cart.billing_address, cart.shipping_address)
-      : true,
+      : true
   )
 
   /**
@@ -183,7 +188,7 @@ export const CheckoutProvider = ({ children }: CheckoutProviderProps) => {
         { option_id: soId },
         {
           onSuccess: ({ cart }) => setCart(cart),
-        },
+        }
       )
     }
   }
@@ -229,7 +234,7 @@ export const CheckoutProvider = ({ children }: CheckoutProviderProps) => {
           onSuccess: ({ cart }) => {
             setCart(cart)
           },
-        },
+        }
       )
     }
   }
@@ -265,7 +270,7 @@ export const CheckoutProvider = ({ children }: CheckoutProviderProps) => {
   const validateRegion = (countryCode: string) => {
     if (regions && cart) {
       const region = regions.find((r) =>
-        r.countries.map((c) => c.iso_2).includes(countryCode),
+        r.countries.map((c) => c.iso_2).includes(countryCode)
       )
 
       if (region && region.id !== cart.region.id) {
@@ -344,7 +349,7 @@ export const useCheckout = () => {
   const form = useFormContext<CheckoutFormValues>()
   if (context === null) {
     throw new Error(
-      "useProductActionContext must be used within a ProductActionProvider",
+      "useProductActionContext must be used within a ProductActionProvider"
     )
   }
   return { ...context, ...form }
@@ -359,7 +364,7 @@ export const useCheckout = () => {
 const mapFormValues = (
   customer?: Omit<Customer, "password_hash">,
   cart?: Omit<Cart, "refundable_amount" | "refunded_total">,
-  currentCountry?: string,
+  currentCountry?: string
 ): CheckoutFormValues => {
   const customerShippingAddress = customer?.shipping_addresses?.[0]
   const customerBillingAddress = customer?.billing_address

--- a/src/lib/context/product-context.tsx
+++ b/src/lib/context/product-context.tsx
@@ -2,7 +2,13 @@ import { canBuy } from "@lib/util/can-buy"
 import { findCheapestPrice } from "@lib/util/prices"
 import isEqual from "lodash/isEqual"
 import { formatVariantPrice, useCart } from "medusa-react"
-import React, { createContext, useContext, useEffect, useMemo, useState } from "react"
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react"
 import { ProductVariant } from "@medusajs/client-types"
 import { useStore } from "./store-context"
 import { ProductWithRelations } from "../../types/medusa"
@@ -167,7 +173,7 @@ export const useProductActions = () => {
   const context = useContext(ProductActionContext)
   if (context === null) {
     throw new Error(
-      "useProductActionContext must be used within a ProductActionProvider",
+      "useProductActionContext must be used within a ProductActionProvider"
     )
   }
   return context

--- a/src/lib/context/product-context.tsx
+++ b/src/lib/context/product-context.tsx
@@ -2,22 +2,17 @@ import { canBuy } from "@lib/util/can-buy"
 import { findCheapestPrice } from "@lib/util/prices"
 import isEqual from "lodash/isEqual"
 import { formatVariantPrice, useCart } from "medusa-react"
-import React, {
-  createContext,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-} from "react"
-import { Product, Variant } from "types/medusa"
+import React, { createContext, useContext, useEffect, useMemo, useState } from "react"
+import { ProductVariant } from "@medusajs/client-types"
 import { useStore } from "./store-context"
+import { ProductWithRelations } from "../../types/medusa"
 
 interface ProductContext {
   formattedPrice: string
   quantity: number
   disabled: boolean
   inStock: boolean
-  variant?: Variant
+  variant?: ProductVariant
   maxQuantityMet: boolean
   options: Record<string, string>
   updateOptions: (options: Record<string, string>) => void
@@ -29,8 +24,8 @@ interface ProductContext {
 const ProductActionContext = createContext<ProductContext | null>(null)
 
 interface ProductProviderProps {
+  product: ProductWithRelations
   children?: React.ReactNode
-  product: Product
 }
 
 export const ProductProvider = ({
@@ -172,7 +167,7 @@ export const useProductActions = () => {
   const context = useContext(ProductActionContext)
   if (context === null) {
     throw new Error(
-      "useProductActionContext must be used within a ProductActionProvider"
+      "useProductActionContext must be used within a ProductActionProvider",
     )
   }
   return context

--- a/src/lib/context/store-context.tsx
+++ b/src/lib/context/store-context.tsx
@@ -1,12 +1,7 @@
 import { medusaClient } from "@lib/config"
 import { handleError } from "@lib/util/handle-error"
-import { Region } from "@medusajs/medusa"
-import {
-  useCart,
-  useCreateLineItem,
-  useDeleteLineItem,
-  useUpdateLineItem,
-} from "medusa-react"
+import { Region, SetRelation } from "@medusajs/client-types"
+import { useCart, useCreateLineItem, useDeleteLineItem, useUpdateLineItem } from "medusa-react"
 import React, { useEffect, useState } from "react"
 import { useCartDropdown } from "./cart-dropdown-context"
 
@@ -28,6 +23,8 @@ interface StoreContext {
   deleteItem: (lineId: string) => void
   resetCart: () => void
 }
+
+type RegionWithCounties = SetRelation<Region, "countries">
 
 const StoreContext = React.createContext<StoreContext | null>(null)
 
@@ -59,7 +56,7 @@ export const StoreProvider = ({ children }: StoreProps) => {
     if (!IS_SERVER) {
       localStorage.setItem(
         REGION_KEY,
-        JSON.stringify({ regionId, countryCode })
+        JSON.stringify({ regionId, countryCode }),
       )
 
       setCountryCode(countryCode)
@@ -102,11 +99,11 @@ export const StoreProvider = ({ children }: StoreProps) => {
             console.error(error)
           }
         },
-      }
+      },
     )
   }
 
-  const ensureRegion = (region: Region, countryCode?: string | null) => {
+  const ensureRegion = (region: RegionWithCounties, countryCode?: string | null) => {
     if (!IS_SERVER) {
       const { regionId, countryCode: defaultCountryCode } = getRegion() || {
         regionId: region.id,
@@ -163,7 +160,7 @@ export const StoreProvider = ({ children }: StoreProps) => {
             console.error(error)
           }
         },
-      }
+      },
     )
   }
 
@@ -187,7 +184,7 @@ export const StoreProvider = ({ children }: StoreProps) => {
             console.error(error)
           }
         },
-      }
+      },
     )
   }
 
@@ -247,7 +244,7 @@ export const StoreProvider = ({ children }: StoreProps) => {
         onError: (error) => {
           handleError(error)
         },
-      }
+      },
     )
   }
 
@@ -264,7 +261,7 @@ export const StoreProvider = ({ children }: StoreProps) => {
         onError: (error) => {
           handleError(error)
         },
-      }
+      },
     )
   }
 
@@ -288,7 +285,7 @@ export const StoreProvider = ({ children }: StoreProps) => {
         onError: (error) => {
           handleError(error)
         },
-      }
+      },
     )
   }
 

--- a/src/lib/context/store-context.tsx
+++ b/src/lib/context/store-context.tsx
@@ -1,7 +1,12 @@
 import { medusaClient } from "@lib/config"
 import { handleError } from "@lib/util/handle-error"
 import { Region, SetRelation } from "@medusajs/client-types"
-import { useCart, useCreateLineItem, useDeleteLineItem, useUpdateLineItem } from "medusa-react"
+import {
+  useCart,
+  useCreateLineItem,
+  useDeleteLineItem,
+  useUpdateLineItem,
+} from "medusa-react"
 import React, { useEffect, useState } from "react"
 import { useCartDropdown } from "./cart-dropdown-context"
 
@@ -56,7 +61,7 @@ export const StoreProvider = ({ children }: StoreProps) => {
     if (!IS_SERVER) {
       localStorage.setItem(
         REGION_KEY,
-        JSON.stringify({ regionId, countryCode }),
+        JSON.stringify({ regionId, countryCode })
       )
 
       setCountryCode(countryCode)
@@ -99,11 +104,14 @@ export const StoreProvider = ({ children }: StoreProps) => {
             console.error(error)
           }
         },
-      },
+      }
     )
   }
 
-  const ensureRegion = (region: RegionWithCounties, countryCode?: string | null) => {
+  const ensureRegion = (
+    region: RegionWithCounties,
+    countryCode?: string | null
+  ) => {
     if (!IS_SERVER) {
       const { regionId, countryCode: defaultCountryCode } = getRegion() || {
         regionId: region.id,
@@ -160,7 +168,7 @@ export const StoreProvider = ({ children }: StoreProps) => {
             console.error(error)
           }
         },
-      },
+      }
     )
   }
 
@@ -184,7 +192,7 @@ export const StoreProvider = ({ children }: StoreProps) => {
             console.error(error)
           }
         },
-      },
+      }
     )
   }
 
@@ -244,7 +252,7 @@ export const StoreProvider = ({ children }: StoreProps) => {
         onError: (error) => {
           handleError(error)
         },
-      },
+      }
     )
   }
 
@@ -261,7 +269,7 @@ export const StoreProvider = ({ children }: StoreProps) => {
         onError: (error) => {
           handleError(error)
         },
-      },
+      }
     )
   }
 
@@ -285,7 +293,7 @@ export const StoreProvider = ({ children }: StoreProps) => {
         onError: (error) => {
           handleError(error)
         },
-      },
+      }
     )
   }
 

--- a/src/lib/data/index.ts
+++ b/src/lib/data/index.ts
@@ -1,5 +1,5 @@
 import { medusaClient } from "@lib/config"
-import { Product, StoreGetProductsParams } from "@medusajs/medusa"
+import { Product, StoreGetProductsParams } from "@medusajs/client-types"
 
 const COL_LIMIT = 15
 

--- a/src/lib/hooks/use-enrich-line-items.tsx
+++ b/src/lib/hooks/use-enrich-line-items.tsx
@@ -1,14 +1,14 @@
-import { LineItem } from "@medusajs/medusa"
 import omit from "lodash/omit"
 import { useCart, useProducts } from "medusa-react"
 import { useMemo } from "react"
+import { LineItemWithRelations } from "../../types/medusa"
 
 /**
  * A hook that returns an array of enriched line items.
  * If you pass an array of line items, it will return those line items with enriched data.
  * Otherwise it will return the line items from the current cart.
  */
-const useEnrichedLineItems = (lineItems?: LineItem[], cartId?: string) => {
+const useEnrichedLineItems = (lineItems?: LineItemWithRelations[], cartId?: string) => {
   const { cart } = useCart()
 
   const queryParams = useMemo(() => {
@@ -38,7 +38,7 @@ const useEnrichedLineItems = (lineItems?: LineItem[], cartId?: string) => {
       return []
     }
 
-    const enrichedItems: Omit<LineItem, "beforeInsert">[] = []
+    const enrichedItems: LineItemWithRelations[] = []
 
     for (const item of currItems) {
       const product = products.find((p) => p.id === item.variant.product_id)

--- a/src/lib/hooks/use-layout-data.tsx
+++ b/src/lib/hooks/use-layout-data.tsx
@@ -1,6 +1,6 @@
 import { medusaClient } from "@lib/config"
 import { getPercentageDiff } from "@lib/util/get-precentage-diff"
-import { Product, ProductCollection, Region } from "@medusajs/medusa"
+import { Product, ProductCollection, Region } from "@medusajs/client-types"
 import { useQuery } from "@tanstack/react-query"
 import { formatAmount, useCart } from "medusa-react"
 import { ProductPreviewType } from "types/global"
@@ -48,7 +48,7 @@ export const useNavigationCollections = () => {
 
 const fetchFeaturedProducts = async (
   cartId: string,
-  region: Region
+  region: Region,
 ): Promise<ProductPreviewType[]> => {
   const products = await medusaClient.products
     .list({
@@ -78,28 +78,28 @@ const fetchFeaturedProducts = async (
         thumbnail: p.thumbnail,
         price: cheapestVariant
           ? {
-              calculated_price: formatAmount({
-                amount: cheapestVariant.calculated_price,
-                region: region,
-                includeTaxes: false,
-              }),
-              original_price: formatAmount({
-                amount: cheapestVariant.original_price,
-                region: region,
-                includeTaxes: false,
-              }),
-              difference: getPercentageDiff(
-                cheapestVariant.original_price,
-                cheapestVariant.calculated_price
-              ),
-              price_type: cheapestVariant.calculated_price_type,
-            }
+            calculated_price: formatAmount({
+              amount: cheapestVariant.calculated_price,
+              region: region,
+              includeTaxes: false,
+            }),
+            original_price: formatAmount({
+              amount: cheapestVariant.original_price,
+              region: region,
+              includeTaxes: false,
+            }),
+            difference: getPercentageDiff(
+              cheapestVariant.original_price,
+              cheapestVariant.calculated_price,
+            ),
+            price_type: cheapestVariant.calculated_price_type,
+          }
           : {
-              calculated_price: "N/A",
-              original_price: "N/A",
-              difference: "N/A",
-              price_type: "default",
-            },
+            calculated_price: "N/A",
+            original_price: "N/A",
+            difference: "N/A",
+            price_type: "default",
+          },
       }
     })
 }
@@ -114,7 +114,7 @@ export const useFeaturedProductsQuery = () => {
       enabled: !!cart?.id && !!cart?.region,
       staleTime: Infinity,
       refetchOnWindowFocus: false,
-    }
+    },
   )
 
   return queryResults

--- a/src/lib/hooks/use-layout-data.tsx
+++ b/src/lib/hooks/use-layout-data.tsx
@@ -48,7 +48,7 @@ export const useNavigationCollections = () => {
 
 const fetchFeaturedProducts = async (
   cartId: string,
-  region: Region,
+  region: Region
 ): Promise<ProductPreviewType[]> => {
   const products = await medusaClient.products
     .list({
@@ -78,28 +78,28 @@ const fetchFeaturedProducts = async (
         thumbnail: p.thumbnail,
         price: cheapestVariant
           ? {
-            calculated_price: formatAmount({
-              amount: cheapestVariant.calculated_price,
-              region: region,
-              includeTaxes: false,
-            }),
-            original_price: formatAmount({
-              amount: cheapestVariant.original_price,
-              region: region,
-              includeTaxes: false,
-            }),
-            difference: getPercentageDiff(
-              cheapestVariant.original_price,
-              cheapestVariant.calculated_price,
-            ),
-            price_type: cheapestVariant.calculated_price_type,
-          }
+              calculated_price: formatAmount({
+                amount: cheapestVariant.calculated_price,
+                region: region,
+                includeTaxes: false,
+              }),
+              original_price: formatAmount({
+                amount: cheapestVariant.original_price,
+                region: region,
+                includeTaxes: false,
+              }),
+              difference: getPercentageDiff(
+                cheapestVariant.original_price,
+                cheapestVariant.calculated_price
+              ),
+              price_type: cheapestVariant.calculated_price_type,
+            }
           : {
-            calculated_price: "N/A",
-            original_price: "N/A",
-            difference: "N/A",
-            price_type: "default",
-          },
+              calculated_price: "N/A",
+              original_price: "N/A",
+              difference: "N/A",
+              price_type: "default",
+            },
       }
     })
 }
@@ -114,7 +114,7 @@ export const useFeaturedProductsQuery = () => {
       enabled: !!cart?.id && !!cart?.region,
       staleTime: Infinity,
       refetchOnWindowFocus: false,
-    },
+    }
   )
 
   return queryResults

--- a/src/lib/hooks/use-previews.tsx
+++ b/src/lib/hooks/use-previews.tsx
@@ -8,7 +8,7 @@ type UsePreviewProps<T> = {
   region?: Region
 }
 
-const usePreviews = <T extends InfiniteProductPage> ({
+const usePreviews = <T extends InfiniteProductPage>({
   pages,
   region,
 }: UsePreviewProps<T>) => {
@@ -24,7 +24,7 @@ const usePreviews = <T extends InfiniteProductPage> ({
     }
 
     const transformedProducts = products.map((p) =>
-      transformProductPreview(p, region),
+      transformProductPreview(p, region)
     )
 
     return transformedProducts

--- a/src/lib/hooks/use-previews.tsx
+++ b/src/lib/hooks/use-previews.tsx
@@ -1,5 +1,5 @@
 import transformProductPreview from "@lib/util/transform-product-preview"
-import { Product, Region } from "@medusajs/medusa"
+import { Product, Region } from "@medusajs/client-types"
 import { useMemo } from "react"
 import { InfiniteProductPage, ProductPreviewType } from "types/global"
 
@@ -8,7 +8,7 @@ type UsePreviewProps<T> = {
   region?: Region
 }
 
-const usePreviews = <T extends InfiniteProductPage>({
+const usePreviews = <T extends InfiniteProductPage> ({
   pages,
   region,
 }: UsePreviewProps<T>) => {
@@ -24,7 +24,7 @@ const usePreviews = <T extends InfiniteProductPage>({
     }
 
     const transformedProducts = products.map((p) =>
-      transformProductPreview(p, region)
+      transformProductPreview(p, region),
     )
 
     return transformedProducts

--- a/src/lib/util/can-buy.ts
+++ b/src/lib/util/can-buy.ts
@@ -1,4 +1,4 @@
-import { ProductVariant } from "@medusajs/medusa"
+import { ProductVariant } from "@medusajs/client-types"
 
 export const canBuy = (variant: Omit<ProductVariant, "beforeInsert">) => {
   return variant.inventory_quantity > 0 || variant.allow_backorder === true

--- a/src/lib/util/prices.ts
+++ b/src/lib/util/prices.ts
@@ -1,8 +1,9 @@
-import { MoneyAmount } from "@medusajs/medusa"
+import { MoneyAmount, ProductVariant, Region, SetRelation } from "@medusajs/client-types"
 import { formatAmount } from "medusa-react"
-import { Region, Variant } from "types/medusa"
 
-export const findCheapestRegionPrice = (variants: Variant[], regionId: string) => {
+type ProductVariantWithPrices = SetRelation<ProductVariant, "prices">
+
+export const findCheapestRegionPrice = (variants: ProductVariantWithPrices[], regionId: string) => {
   const regionPrices = variants.reduce((acc, v) => {
     const price = v.prices.find((p) => p.region_id === regionId)
     if (price) {
@@ -29,8 +30,8 @@ export const findCheapestRegionPrice = (variants: Variant[], regionId: string) =
 }
 
 export const findCheapestCurrencyPrice = (
-  variants: Variant[],
-  currencyCode: string
+  variants: ProductVariantWithPrices[],
+  currencyCode: string,
 ) => {
   const currencyPrices = variants.reduce((acc, v) => {
     const price = v.prices.find((p) => p.currency_code === currencyCode)
@@ -57,27 +58,27 @@ export const findCheapestCurrencyPrice = (
   return cheapestPrice
 }
 
-export const findCheapestPrice = (variants: Variant[], region: Region) => {
+export const findCheapestPrice = (variants: ProductVariantWithPrices[], region: Region) => {
   const { id, currency_code } = region
-  
+
   let cheapestPrice = findCheapestRegionPrice(variants, id)
 
-      if (!cheapestPrice) {
-        cheapestPrice = findCheapestCurrencyPrice(
-          variants,
-          currency_code
-        )
-      }
+  if (!cheapestPrice) {
+    cheapestPrice = findCheapestCurrencyPrice(
+      variants,
+      currency_code,
+    )
+  }
 
-      if (cheapestPrice) {
-        return formatAmount({
-          amount: cheapestPrice.amount,
-          region: region,
-        })
-      }
+  if (cheapestPrice) {
+    return formatAmount({
+      amount: cheapestPrice.amount,
+      region: region,
+    })
+  }
 
-      // if we can't find any price that matches the current region,
-      // either by id or currency, then the product is not available in
-      // the current region
-      return "Not available in your region"
+  // if we can't find any price that matches the current region,
+  // either by id or currency, then the product is not available in
+  // the current region
+  return "Not available in your region"
 }

--- a/src/lib/util/prices.ts
+++ b/src/lib/util/prices.ts
@@ -1,9 +1,17 @@
-import { MoneyAmount, ProductVariant, Region, SetRelation } from "@medusajs/client-types"
+import {
+  MoneyAmount,
+  ProductVariant,
+  Region,
+  SetRelation,
+} from "@medusajs/client-types"
 import { formatAmount } from "medusa-react"
 
 type ProductVariantWithPrices = SetRelation<ProductVariant, "prices">
 
-export const findCheapestRegionPrice = (variants: ProductVariantWithPrices[], regionId: string) => {
+export const findCheapestRegionPrice = (
+  variants: ProductVariantWithPrices[],
+  regionId: string
+) => {
   const regionPrices = variants.reduce((acc, v) => {
     const price = v.prices.find((p) => p.region_id === regionId)
     if (price) {
@@ -31,7 +39,7 @@ export const findCheapestRegionPrice = (variants: ProductVariantWithPrices[], re
 
 export const findCheapestCurrencyPrice = (
   variants: ProductVariantWithPrices[],
-  currencyCode: string,
+  currencyCode: string
 ) => {
   const currencyPrices = variants.reduce((acc, v) => {
     const price = v.prices.find((p) => p.currency_code === currencyCode)
@@ -58,16 +66,16 @@ export const findCheapestCurrencyPrice = (
   return cheapestPrice
 }
 
-export const findCheapestPrice = (variants: ProductVariantWithPrices[], region: Region) => {
+export const findCheapestPrice = (
+  variants: ProductVariantWithPrices[],
+  region: Region
+) => {
   const { id, currency_code } = region
 
   let cheapestPrice = findCheapestRegionPrice(variants, id)
 
   if (!cheapestPrice) {
-    cheapestPrice = findCheapestCurrencyPrice(
-      variants,
-      currency_code,
-    )
+    cheapestPrice = findCheapestCurrencyPrice(variants, currency_code)
   }
 
   if (cheapestPrice) {

--- a/src/lib/util/transform-product-preview.ts
+++ b/src/lib/util/transform-product-preview.ts
@@ -6,7 +6,7 @@ import { CalculatedVariant } from "types/medusa"
 
 const transformProductPreview = (
   product: Product,
-  region: Region,
+  region: Region
 ): ProductPreviewType => {
   const variants = product.variants as CalculatedVariant[]
 
@@ -28,22 +28,22 @@ const transformProductPreview = (
     thumbnail: product.thumbnail,
     price: cheapestVariant
       ? {
-        calculated_price: formatAmount({
-          amount: cheapestVariant.calculated_price,
-          region: region,
-          includeTaxes: false,
-        }),
-        original_price: formatAmount({
-          amount: cheapestVariant.original_price,
-          region: region,
-          includeTaxes: false,
-        }),
-        difference: getPercentageDiff(
-          cheapestVariant.original_price,
-          cheapestVariant.calculated_price,
-        ),
-        price_type: cheapestVariant.calculated_price_type,
-      }
+          calculated_price: formatAmount({
+            amount: cheapestVariant.calculated_price,
+            region: region,
+            includeTaxes: false,
+          }),
+          original_price: formatAmount({
+            amount: cheapestVariant.original_price,
+            region: region,
+            includeTaxes: false,
+          }),
+          difference: getPercentageDiff(
+            cheapestVariant.original_price,
+            cheapestVariant.calculated_price
+          ),
+          price_type: cheapestVariant.calculated_price_type,
+        }
       : undefined,
   }
 }

--- a/src/lib/util/transform-product-preview.ts
+++ b/src/lib/util/transform-product-preview.ts
@@ -1,12 +1,12 @@
 import { getPercentageDiff } from "@lib/util/get-precentage-diff"
-import { Product, Region } from "@medusajs/medusa"
+import { Product, Region } from "@medusajs/client-types"
 import { formatAmount } from "medusa-react"
 import { ProductPreviewType } from "types/global"
 import { CalculatedVariant } from "types/medusa"
 
 const transformProductPreview = (
   product: Product,
-  region: Region
+  region: Region,
 ): ProductPreviewType => {
   const variants = product.variants as CalculatedVariant[]
 
@@ -28,22 +28,22 @@ const transformProductPreview = (
     thumbnail: product.thumbnail,
     price: cheapestVariant
       ? {
-          calculated_price: formatAmount({
-            amount: cheapestVariant.calculated_price,
-            region: region,
-            includeTaxes: false,
-          }),
-          original_price: formatAmount({
-            amount: cheapestVariant.original_price,
-            region: region,
-            includeTaxes: false,
-          }),
-          difference: getPercentageDiff(
-            cheapestVariant.original_price,
-            cheapestVariant.calculated_price
-          ),
-          price_type: cheapestVariant.calculated_price_type,
-        }
+        calculated_price: formatAmount({
+          amount: cheapestVariant.calculated_price,
+          region: region,
+          includeTaxes: false,
+        }),
+        original_price: formatAmount({
+          amount: cheapestVariant.original_price,
+          region: region,
+          includeTaxes: false,
+        }),
+        difference: getPercentageDiff(
+          cheapestVariant.original_price,
+          cheapestVariant.calculated_price,
+        ),
+        price_type: cheapestVariant.calculated_price_type,
+      }
       : undefined,
   }
 }

--- a/src/modules/account/components/address-book/index.tsx
+++ b/src/modules/account/components/address-book/index.tsx
@@ -1,10 +1,12 @@
-import { Customer } from "@medusajs/medusa"
+import { Customer, SetRelation } from "@medusajs/client-types"
 import React from "react"
 import AddAddress from "../address-card/add-address"
 import EditAddress from "../address-card/edit-address-modal"
 
+type CustomerWithShippingAddresses = SetRelation<Customer, "shipping_addresses">
+
 type AddressBookProps = {
-  customer: Omit<Customer, "password_hash">
+  customer: CustomerWithShippingAddresses
 }
 
 const AddressBook: React.FC<AddressBookProps> = ({ customer }) => {

--- a/src/modules/account/components/address-card/edit-address-modal.tsx
+++ b/src/modules/account/components/address-card/edit-address-modal.tsx
@@ -1,7 +1,7 @@
 import { medusaClient } from "@lib/config"
 import { useAccount } from "@lib/context/account-context"
 import useToggleState from "@lib/hooks/use-toggle-state"
-import { Address } from "@medusajs/medusa"
+import { Address } from "@medusajs/client-types"
 import CountrySelect from "@modules/checkout/components/country-select"
 import Button from "@modules/common/components/button"
 import Input from "@modules/common/components/input"
@@ -103,7 +103,7 @@ const EditAddress: React.FC<EditAddressProps> = ({
           "border border-gray-200 p-5 min-h-[220px] h-full w-full flex flex-col justify-between transition-colors",
           {
             "border-gray-900": isActive,
-          }
+          },
         )}
       >
         <div className="flex flex-col">

--- a/src/modules/account/components/address-card/edit-address-modal.tsx
+++ b/src/modules/account/components/address-card/edit-address-modal.tsx
@@ -103,7 +103,7 @@ const EditAddress: React.FC<EditAddressProps> = ({
           "border border-gray-200 p-5 min-h-[220px] h-full w-full flex flex-col justify-between transition-colors",
           {
             "border-gray-900": isActive,
-          },
+          }
         )}
       >
         <div className="flex flex-col">

--- a/src/modules/account/components/login-details/edit-email-modal.tsx
+++ b/src/modules/account/components/login-details/edit-email-modal.tsx
@@ -1,7 +1,7 @@
 import { useAccount } from "@lib/context/account-context"
 import useToggleState from "@lib/hooks/use-toggle-state"
 import { emailRegex } from "@lib/util/regex"
-import { Customer } from "@medusajs/medusa"
+import { Customer } from "@medusajs/client-types"
 import EditButton from "@modules/account/components/edit-button"
 import Button from "@modules/common/components/button"
 import Input from "@modules/common/components/input"
@@ -60,7 +60,7 @@ const EditEmailModal: React.FC<EditEmailModalProps> = ({ customer }) => {
           setSubmitting(false)
           setError("Unable to update email, try again later.")
         },
-      }
+      },
     )
   })
 

--- a/src/modules/account/components/login-details/edit-email-modal.tsx
+++ b/src/modules/account/components/login-details/edit-email-modal.tsx
@@ -60,7 +60,7 @@ const EditEmailModal: React.FC<EditEmailModalProps> = ({ customer }) => {
           setSubmitting(false)
           setError("Unable to update email, try again later.")
         },
-      },
+      }
     )
   })
 

--- a/src/modules/account/components/login-details/edit-password-modal.tsx
+++ b/src/modules/account/components/login-details/edit-password-modal.tsx
@@ -1,7 +1,7 @@
 import { medusaClient } from "@lib/config"
 import { useAccount } from "@lib/context/account-context"
 import useToggleState from "@lib/hooks/use-toggle-state"
-import { Customer } from "@medusajs/medusa"
+import { Customer } from "@medusajs/client-types"
 import EditButton from "@modules/account/components/edit-button"
 import Button from "@modules/common/components/button"
 import Input from "@modules/common/components/input"
@@ -82,7 +82,7 @@ const EditPasswordModal: React.FC<EditPasswordModalProps> = ({ customer }) => {
           setSubmitting(false)
           setError("Unable to update password, try again later.")
         },
-      }
+      },
     )
   })
 

--- a/src/modules/account/components/login-details/edit-password-modal.tsx
+++ b/src/modules/account/components/login-details/edit-password-modal.tsx
@@ -82,7 +82,7 @@ const EditPasswordModal: React.FC<EditPasswordModalProps> = ({ customer }) => {
           setSubmitting(false)
           setError("Unable to update password, try again later.")
         },
-      },
+      }
     )
   })
 

--- a/src/modules/account/components/login-details/index.tsx
+++ b/src/modules/account/components/login-details/index.tsx
@@ -1,4 +1,4 @@
-import { Customer } from "@medusajs/medusa"
+import { Customer } from "@medusajs/client-types"
 import React from "react"
 import Detail from "../detail-container"
 import EditEmailModal from "./edit-email-modal"

--- a/src/modules/account/components/order-card/index.tsx
+++ b/src/modules/account/components/order-card/index.tsx
@@ -1,12 +1,14 @@
-import { Order } from "@medusajs/medusa"
+import { Order, SetRelation } from "@medusajs/client-types"
 import Button from "@modules/common/components/button"
 import Thumbnail from "@modules/products/components/thumbnail"
 import { formatAmount } from "medusa-react"
 import Link from "next/link"
 import { useMemo } from "react"
 
+type OrderWithItemsWithRegionWithTotal = SetRelation<Order, "items" | "region" | "total">
+
 type OrderCardProps = {
-  order: Omit<Order, "beforeInsert">
+  order: OrderWithItemsWithRegionWithTotal
 }
 
 const OrderCard = ({ order }: OrderCardProps) => {

--- a/src/modules/account/components/overview/index.tsx
+++ b/src/modules/account/components/overview/index.tsx
@@ -1,4 +1,4 @@
-import { Customer, Order } from "@medusajs/medusa"
+import { Customer, Order, SetRelation } from "@medusajs/client-types"
 import ChevronDown from "@modules/common/icons/chevron-down"
 import MapPin from "@modules/common/icons/map-pin"
 import Package from "@modules/common/icons/package"
@@ -6,9 +6,11 @@ import User from "@modules/common/icons/user"
 import { formatAmount } from "medusa-react"
 import Link from "next/link"
 
+type OrderWithRegionWithTotal = SetRelation<Order, "region" | "total">
+
 type OverviewProps = {
-  orders?: Order[]
-  customer?: Omit<Customer, "password_hash">
+  orders?: OrderWithRegionWithTotal[]
+  customer?: Customer
 }
 
 const Overview = ({ orders, customer }: OverviewProps) => {

--- a/src/modules/account/components/profile-billing-address/index.tsx
+++ b/src/modules/account/components/profile-billing-address/index.tsx
@@ -1,5 +1,9 @@
 import { useAccount } from "@lib/context/account-context"
-import { Customer, SetRelation, StorePostCustomersCustomerReq } from "@medusajs/client-types"
+import {
+  Customer,
+  SetRelation,
+  StorePostCustomersCustomerReq,
+} from "@medusajs/client-types"
 import Input from "@modules/common/components/input"
 import NativeSelect from "@modules/common/components/native-select"
 import { useRegions, useUpdateMe } from "medusa-react"
@@ -97,7 +101,7 @@ const ProfileBillingAddress: React.FC<MyInformationProps> = ({ customer }) => {
         onSuccess: () => {
           refetchCustomer()
         },
-      },
+      }
     )
   }
 
@@ -108,7 +112,7 @@ const ProfileBillingAddress: React.FC<MyInformationProps> = ({ customer }) => {
 
     const country =
       regionOptions?.find(
-        (country) => country.value === customer.billing_address.country_code,
+        (country) => country.value === customer.billing_address.country_code
       )?.label || customer.billing_address.country_code?.toUpperCase()
 
     return (

--- a/src/modules/account/components/profile-billing-address/index.tsx
+++ b/src/modules/account/components/profile-billing-address/index.tsx
@@ -1,5 +1,5 @@
 import { useAccount } from "@lib/context/account-context"
-import { Customer, StorePostCustomersCustomerReq } from "@medusajs/medusa"
+import { Customer, SetRelation, StorePostCustomersCustomerReq } from "@medusajs/client-types"
 import Input from "@modules/common/components/input"
 import NativeSelect from "@modules/common/components/native-select"
 import { useRegions, useUpdateMe } from "medusa-react"
@@ -7,8 +7,10 @@ import React, { useEffect, useMemo } from "react"
 import { useForm, useWatch } from "react-hook-form"
 import AccountInfo from "../account-info"
 
+type CustomerWithBillingAddress = SetRelation<Customer, "billing_address">
+
 type MyInformationProps = {
-  customer: Omit<Customer, "password_hash">
+  customer: CustomerWithBillingAddress
 }
 
 type UpdateCustomerNameFormData = Pick<
@@ -95,7 +97,7 @@ const ProfileBillingAddress: React.FC<MyInformationProps> = ({ customer }) => {
         onSuccess: () => {
           refetchCustomer()
         },
-      }
+      },
     )
   }
 
@@ -106,7 +108,7 @@ const ProfileBillingAddress: React.FC<MyInformationProps> = ({ customer }) => {
 
     const country =
       regionOptions?.find(
-        (country) => country.value === customer.billing_address.country_code
+        (country) => country.value === customer.billing_address.country_code,
       )?.label || customer.billing_address.country_code?.toUpperCase()
 
     return (

--- a/src/modules/account/components/profile-email/index.tsx
+++ b/src/modules/account/components/profile-email/index.tsx
@@ -16,7 +16,7 @@ type UpdateCustomerEmailFormData = {
 
 const ProfileEmail: React.FC<MyInformationProps> = ({ customer }) => {
   const [errorMessage, setErrorMessage] = React.useState<string | undefined>(
-    undefined,
+    undefined
   )
 
   const {
@@ -65,7 +65,7 @@ const ProfileEmail: React.FC<MyInformationProps> = ({ customer }) => {
         onError: () => {
           setErrorMessage("Email already in use")
         },
-      },
+      }
     )
   }
 

--- a/src/modules/account/components/profile-email/index.tsx
+++ b/src/modules/account/components/profile-email/index.tsx
@@ -1,5 +1,5 @@
 import { useAccount } from "@lib/context/account-context"
-import { Customer } from "@medusajs/medusa"
+import { Customer } from "@medusajs/client-types"
 import Input from "@modules/common/components/input"
 import { useUpdateMe } from "medusa-react"
 import React, { useEffect } from "react"
@@ -16,7 +16,7 @@ type UpdateCustomerEmailFormData = {
 
 const ProfileEmail: React.FC<MyInformationProps> = ({ customer }) => {
   const [errorMessage, setErrorMessage] = React.useState<string | undefined>(
-    undefined
+    undefined,
   )
 
   const {
@@ -65,7 +65,7 @@ const ProfileEmail: React.FC<MyInformationProps> = ({ customer }) => {
         onError: () => {
           setErrorMessage("Email already in use")
         },
-      }
+      },
     )
   }
 

--- a/src/modules/account/components/profile-name/index.tsx
+++ b/src/modules/account/components/profile-name/index.tsx
@@ -65,7 +65,7 @@ const ProfileName: React.FC<MyInformationProps> = ({ customer }) => {
         onSuccess: () => {
           refetchCustomer()
         },
-      },
+      }
     )
   }
 

--- a/src/modules/account/components/profile-name/index.tsx
+++ b/src/modules/account/components/profile-name/index.tsx
@@ -1,5 +1,5 @@
 import { useAccount } from "@lib/context/account-context"
-import { Customer } from "@medusajs/medusa"
+import { Customer } from "@medusajs/client-types"
 import Input from "@modules/common/components/input"
 import { useUpdateMe } from "medusa-react"
 import React, { useEffect } from "react"
@@ -7,7 +7,7 @@ import { useForm, useWatch } from "react-hook-form"
 import AccountInfo from "../account-info"
 
 type MyInformationProps = {
-  customer: Omit<Customer, "password_hash">
+  customer: Customer
 }
 
 type UpdateCustomerNameFormData = {
@@ -24,8 +24,8 @@ const ProfileName: React.FC<MyInformationProps> = ({ customer }) => {
     formState: { errors },
   } = useForm<UpdateCustomerNameFormData>({
     defaultValues: {
-      first_name: customer.first_name,
-      last_name: customer.last_name,
+      first_name: customer.first_name ?? "",
+      last_name: customer.last_name ?? "",
     },
   })
 
@@ -41,8 +41,8 @@ const ProfileName: React.FC<MyInformationProps> = ({ customer }) => {
 
   useEffect(() => {
     reset({
-      first_name: customer.first_name,
-      last_name: customer.last_name,
+      first_name: customer.first_name ?? "",
+      last_name: customer.last_name ?? "",
     })
   }, [customer, reset])
 
@@ -65,7 +65,7 @@ const ProfileName: React.FC<MyInformationProps> = ({ customer }) => {
         onSuccess: () => {
           refetchCustomer()
         },
-      }
+      },
     )
   }
 

--- a/src/modules/account/components/profile-password/index.tsx
+++ b/src/modules/account/components/profile-password/index.tsx
@@ -1,5 +1,5 @@
 import { medusaClient } from "@lib/config"
-import { Customer } from "@medusajs/medusa"
+import { Customer } from "@medusajs/client-types"
 import Input from "@modules/common/components/input"
 import { useUpdateMe } from "medusa-react"
 import React, { useEffect } from "react"
@@ -18,7 +18,7 @@ type UpdateCustomerPasswordFormData = {
 
 const ProfileName: React.FC<MyInformationProps> = ({ customer }) => {
   const [errorMessage, setErrorMessage] = React.useState<string | undefined>(
-    undefined
+    undefined,
   )
   const {
     register,

--- a/src/modules/account/components/profile-password/index.tsx
+++ b/src/modules/account/components/profile-password/index.tsx
@@ -18,7 +18,7 @@ type UpdateCustomerPasswordFormData = {
 
 const ProfileName: React.FC<MyInformationProps> = ({ customer }) => {
   const [errorMessage, setErrorMessage] = React.useState<string | undefined>(
-    undefined,
+    undefined
   )
   const {
     register,

--- a/src/modules/account/components/profile-phone/index.tsx
+++ b/src/modules/account/components/profile-phone/index.tsx
@@ -1,5 +1,5 @@
 import { useAccount } from "@lib/context/account-context"
-import { Customer } from "@medusajs/medusa"
+import { Customer } from "@medusajs/client-types"
 import Input from "@modules/common/components/input"
 import { useUpdateMe } from "medusa-react"
 import React, { useEffect } from "react"
@@ -23,7 +23,7 @@ const ProfilePhone: React.FC<MyInformationProps> = ({ customer }) => {
     formState: { errors },
   } = useForm<UpdateCustomerPhoneFormData>({
     defaultValues: {
-      phone: customer.phone,
+      phone: customer.phone ?? "",
     },
   })
 
@@ -39,7 +39,7 @@ const ProfilePhone: React.FC<MyInformationProps> = ({ customer }) => {
 
   useEffect(() => {
     reset({
-      phone: customer.phone,
+      phone: customer.phone ?? "",
     })
   }, [customer, reset])
 
@@ -58,7 +58,7 @@ const ProfilePhone: React.FC<MyInformationProps> = ({ customer }) => {
         onSuccess: () => {
           refetchCustomer()
         },
-      }
+      },
     )
   }
 

--- a/src/modules/account/components/profile-phone/index.tsx
+++ b/src/modules/account/components/profile-phone/index.tsx
@@ -58,7 +58,7 @@ const ProfilePhone: React.FC<MyInformationProps> = ({ customer }) => {
         onSuccess: () => {
           refetchCustomer()
         },
-      },
+      }
     )
   }
 

--- a/src/modules/cart/components/item/index.tsx
+++ b/src/modules/cart/components/item/index.tsx
@@ -1,13 +1,14 @@
 import { useStore } from "@lib/context/store-context"
-import { LineItem, Region } from "@medusajs/medusa"
+import { Region } from "@medusajs/client-types"
 import LineItemOptions from "@modules/common/components/line-item-options"
 import LineItemPrice from "@modules/common/components/line-item-price"
 import NativeSelect from "@modules/common/components/native-select"
 import Trash from "@modules/common/icons/trash"
 import Thumbnail from "@modules/products/components/thumbnail"
+import { LineItemWithRelations } from "../../../../types/medusa"
 
 type ItemProps = {
-  item: Omit<LineItem, "beforeInsert">
+  item: LineItemWithRelations
   region: Region
 }
 

--- a/src/modules/cart/templates/items.tsx
+++ b/src/modules/cart/templates/items.tsx
@@ -1,9 +1,10 @@
-import { LineItem, Region } from "@medusajs/medusa"
+import { Region } from "@medusajs/client-types"
 import Item from "@modules/cart/components/item"
 import SkeletonLineItem from "@modules/skeletons/components/skeleton-line-item"
+import { LineItemWithRelations } from "../../../types/medusa"
 
 type ItemsTemplateProps = {
-  items?: Omit<LineItem, "beforeInsert">[]
+  items?: LineItemWithRelations[]
   region?: Region
 }
 
@@ -16,15 +17,15 @@ const ItemsTemplate = ({ items, region }: ItemsTemplateProps) => {
       <div className="grid grid-cols-1 gap-y-8 py-8">
         {items && region
           ? items
-              .sort((a, b) => {
-                return a.created_at > b.created_at ? -1 : 1
-              })
-              .map((item) => {
-                return <Item key={item.id} item={item} region={region} />
-              })
+            .sort((a, b) => {
+              return a.created_at > b.created_at ? -1 : 1
+            })
+            .map((item) => {
+              return <Item key={item.id} item={item} region={region} />
+            })
           : Array.from(Array(5).keys()).map((i) => {
-              return <SkeletonLineItem key={i} />
-            })}
+            return <SkeletonLineItem key={i} />
+          })}
       </div>
     </div>
   )

--- a/src/modules/cart/templates/items.tsx
+++ b/src/modules/cart/templates/items.tsx
@@ -17,15 +17,15 @@ const ItemsTemplate = ({ items, region }: ItemsTemplateProps) => {
       <div className="grid grid-cols-1 gap-y-8 py-8">
         {items && region
           ? items
-            .sort((a, b) => {
-              return a.created_at > b.created_at ? -1 : 1
-            })
-            .map((item) => {
-              return <Item key={item.id} item={item} region={region} />
-            })
+              .sort((a, b) => {
+                return a.created_at > b.created_at ? -1 : 1
+              })
+              .map((item) => {
+                return <Item key={item.id} item={item} region={region} />
+              })
           : Array.from(Array(5).keys()).map((i) => {
-            return <SkeletonLineItem key={i} />
-          })}
+              return <SkeletonLineItem key={i} />
+            })}
       </div>
     </div>
   )

--- a/src/modules/cart/templates/summary.tsx
+++ b/src/modules/cart/templates/summary.tsx
@@ -1,10 +1,12 @@
-import { Cart } from "@medusajs/medusa"
+import { Cart, SetRelation } from "@medusajs/client-types"
 import Button from "@modules/common/components/button"
 import CartTotals from "@modules/common/components/cart-totals"
 import Link from "next/link"
 
+type CartWithRegion = SetRelation<Cart, "region">
+
 type SummaryProps = {
-  cart: Omit<Cart, "refundable_amount" | "refunded_total">
+  cart: CartWithRegion
 }
 
 const Summary = ({ cart }: SummaryProps) => {

--- a/src/modules/checkout/components/address-select/index.tsx
+++ b/src/modules/checkout/components/address-select/index.tsx
@@ -44,7 +44,7 @@ const AddressSelect = ({ addresses }: AddressSelectProps) => {
           "metadata",
           "customer_id",
         ]),
-        currentShippingAddress,
+        currentShippingAddress
       )
 
       if (checkEquality) {
@@ -56,8 +56,7 @@ const AddressSelect = ({ addresses }: AddressSelectProps) => {
   return (
     <Listbox onChange={handleSelect} value={selected}>
       <div className="relative">
-        <Listbox.Button
-          className="relative w-full flex justify-between items-center px-4 py-[10px] text-left bg-white cursor-default focus:outline-none border border-gray-200 focus-visible:ring-2 focus-visible:ring-opacity-75 focus-visible:ring-white focus-visible:ring-offset-gray-300 focus-visible:ring-offset-2 focus-visible:border-gray-300 text-base-regular">
+        <Listbox.Button className="relative w-full flex justify-between items-center px-4 py-[10px] text-left bg-white cursor-default focus:outline-none border border-gray-200 focus-visible:ring-2 focus-visible:ring-opacity-75 focus-visible:ring-white focus-visible:ring-offset-gray-300 focus-visible:ring-offset-2 focus-visible:border-gray-300 text-base-regular">
           {({ open }) => (
             <>
               <span className="block truncate">
@@ -78,8 +77,7 @@ const AddressSelect = ({ addresses }: AddressSelectProps) => {
           leaveFrom="opacity-100"
           leaveTo="opacity-0"
         >
-          <Listbox.Options
-            className="absolute z-20 w-full overflow-auto text-small-regular bg-white border border-gray-200 border-top-0 max-h-60 focus:outline-none sm:text-sm">
+          <Listbox.Options className="absolute z-20 w-full overflow-auto text-small-regular bg-white border border-gray-200 border-top-0 max-h-60 focus:outline-none sm:text-sm">
             {addresses.map((address) => {
               return (
                 <Listbox.Option

--- a/src/modules/checkout/components/address-select/index.tsx
+++ b/src/modules/checkout/components/address-select/index.tsx
@@ -1,6 +1,6 @@
 import { Listbox, Transition } from "@headlessui/react"
 import { useCheckout } from "@lib/context/checkout-context"
-import { Address } from "@medusajs/medusa"
+import { Address } from "@medusajs/client-types"
 import Radio from "@modules/common/components/radio"
 import ChevronDown from "@modules/common/icons/chevron-down"
 import clsx from "clsx"
@@ -44,7 +44,7 @@ const AddressSelect = ({ addresses }: AddressSelectProps) => {
           "metadata",
           "customer_id",
         ]),
-        currentShippingAddress
+        currentShippingAddress,
       )
 
       if (checkEquality) {
@@ -56,7 +56,8 @@ const AddressSelect = ({ addresses }: AddressSelectProps) => {
   return (
     <Listbox onChange={handleSelect} value={selected}>
       <div className="relative">
-        <Listbox.Button className="relative w-full flex justify-between items-center px-4 py-[10px] text-left bg-white cursor-default focus:outline-none border border-gray-200 focus-visible:ring-2 focus-visible:ring-opacity-75 focus-visible:ring-white focus-visible:ring-offset-gray-300 focus-visible:ring-offset-2 focus-visible:border-gray-300 text-base-regular">
+        <Listbox.Button
+          className="relative w-full flex justify-between items-center px-4 py-[10px] text-left bg-white cursor-default focus:outline-none border border-gray-200 focus-visible:ring-2 focus-visible:ring-opacity-75 focus-visible:ring-white focus-visible:ring-offset-gray-300 focus-visible:ring-offset-2 focus-visible:border-gray-300 text-base-regular">
           {({ open }) => (
             <>
               <span className="block truncate">
@@ -77,7 +78,8 @@ const AddressSelect = ({ addresses }: AddressSelectProps) => {
           leaveFrom="opacity-100"
           leaveTo="opacity-0"
         >
-          <Listbox.Options className="absolute z-20 w-full overflow-auto text-small-regular bg-white border border-gray-200 border-top-0 max-h-60 focus:outline-none sm:text-sm">
+          <Listbox.Options
+            className="absolute z-20 w-full overflow-auto text-small-regular bg-white border border-gray-200 border-top-0 max-h-60 focus:outline-none sm:text-sm">
             {addresses.map((address) => {
               return (
                 <Listbox.Option

--- a/src/modules/checkout/components/discount-code/index.tsx
+++ b/src/modules/checkout/components/discount-code/index.tsx
@@ -1,5 +1,5 @@
 import { medusaClient } from "@lib/config"
-import { Cart } from "@medusajs/medusa"
+import { Cart, Discount, Merge, SetRelation } from "@medusajs/client-types"
 import Button from "@modules/common/components/button"
 import Input from "@modules/common/components/input"
 import Trash from "@modules/common/icons/trash"
@@ -12,8 +12,12 @@ type DiscountFormValues = {
   discount_code: string
 }
 
+type CartWithDiscountsWithRegion = Merge<SetRelation<Cart, "discounts" | "region">, {
+  discounts: Array<SetRelation<Discount, "rule">>
+}>
+
 type DiscountCodeProps = {
-  cart: Omit<Cart, "refundable_amount" | "refunded_total">
+  cart: CartWithDiscountsWithRegion
 }
 
 const DiscountCode: React.FC<DiscountCodeProps> = ({ cart }) => {
@@ -24,7 +28,7 @@ const DiscountCode: React.FC<DiscountCodeProps> = ({ cart }) => {
   const { isLoading: mutationLoading, mutate: removeDiscount } = useMutation(
     (payload: { cartId: string; code: string }) => {
       return medusaClient.carts.deleteDiscount(payload.cartId, payload.code)
-    }
+    },
   )
 
   const appliedDiscount = useMemo(() => {
@@ -70,10 +74,10 @@ const DiscountCode: React.FC<DiscountCodeProps> = ({ cart }) => {
             },
             {
               shouldFocus: true,
-            }
+            },
           )
         },
-      }
+      },
     )
   }
 
@@ -84,7 +88,7 @@ const DiscountCode: React.FC<DiscountCodeProps> = ({ cart }) => {
         onSuccess: ({ cart }) => {
           setCart(cart)
         },
-      }
+      },
     )
   }
 

--- a/src/modules/checkout/components/discount-code/index.tsx
+++ b/src/modules/checkout/components/discount-code/index.tsx
@@ -12,9 +12,12 @@ type DiscountFormValues = {
   discount_code: string
 }
 
-type CartWithDiscountsWithRegion = Merge<SetRelation<Cart, "discounts" | "region">, {
-  discounts: Array<SetRelation<Discount, "rule">>
-}>
+type CartWithDiscountsWithRegion = Merge<
+  SetRelation<Cart, "discounts" | "region">,
+  {
+    discounts: Array<SetRelation<Discount, "rule">>
+  }
+>
 
 type DiscountCodeProps = {
   cart: CartWithDiscountsWithRegion
@@ -28,7 +31,7 @@ const DiscountCode: React.FC<DiscountCodeProps> = ({ cart }) => {
   const { isLoading: mutationLoading, mutate: removeDiscount } = useMutation(
     (payload: { cartId: string; code: string }) => {
       return medusaClient.carts.deleteDiscount(payload.cartId, payload.code)
-    },
+    }
   )
 
   const appliedDiscount = useMemo(() => {
@@ -74,10 +77,10 @@ const DiscountCode: React.FC<DiscountCodeProps> = ({ cart }) => {
             },
             {
               shouldFocus: true,
-            },
+            }
           )
         },
-      },
+      }
     )
   }
 
@@ -88,7 +91,7 @@ const DiscountCode: React.FC<DiscountCodeProps> = ({ cart }) => {
         onSuccess: ({ cart }) => {
           setCart(cart)
         },
-      },
+      }
     )
   }
 

--- a/src/modules/checkout/components/gift-card/index.tsx
+++ b/src/modules/checkout/components/gift-card/index.tsx
@@ -50,10 +50,10 @@ const GiftCard: React.FC<GiftCardProps> = ({ cart }) => {
             },
             {
               shouldFocus: true,
-            },
+            }
           )
         },
-      },
+      }
     )
   }
 
@@ -64,7 +64,7 @@ const GiftCard: React.FC<GiftCardProps> = ({ cart }) => {
       },
       {
         onSuccess: ({ cart }) => setCart(cart),
-      },
+      }
     )
   }
 

--- a/src/modules/checkout/components/gift-card/index.tsx
+++ b/src/modules/checkout/components/gift-card/index.tsx
@@ -1,4 +1,4 @@
-import { Cart } from "@medusajs/medusa"
+import { Cart } from "@medusajs/client-types"
 import Button from "@modules/common/components/button"
 import Input from "@modules/common/components/input"
 import Trash from "@modules/common/icons/trash"
@@ -50,10 +50,10 @@ const GiftCard: React.FC<GiftCardProps> = ({ cart }) => {
             },
             {
               shouldFocus: true,
-            }
+            },
           )
         },
-      }
+      },
     )
   }
 
@@ -64,7 +64,7 @@ const GiftCard: React.FC<GiftCardProps> = ({ cart }) => {
       },
       {
         onSuccess: ({ cart }) => setCart(cart),
-      }
+      },
     )
   }
 

--- a/src/modules/checkout/components/payment-button/index.tsx
+++ b/src/modules/checkout/components/payment-button/index.tsx
@@ -68,7 +68,7 @@ const StripePaymentButton = ({
   const [disabled, setDisabled] = useState(false)
   const [submitting, setSubmitting] = useState(false)
   const [errorMessage, setErrorMessage] = useState<string | undefined>(
-    undefined,
+    undefined
   )
 
   const { cart } = useCart()
@@ -173,7 +173,7 @@ const PayPalPaymentButton = ({
 }) => {
   const [submitting, setSubmitting] = useState(false)
   const [errorMessage, setErrorMessage] = useState<string | undefined>(
-    undefined,
+    undefined
   )
 
   const { cart } = useCart()
@@ -181,7 +181,7 @@ const PayPalPaymentButton = ({
 
   const handlePayment = async (
     _data: OnApproveData,
-    actions: OnApproveActions,
+    actions: OnApproveActions
   ) => {
     actions?.order
       ?.authorize()

--- a/src/modules/checkout/components/payment-button/index.tsx
+++ b/src/modules/checkout/components/payment-button/index.tsx
@@ -1,5 +1,5 @@
 import { useCheckout } from "@lib/context/checkout-context"
-import { PaymentSession } from "@medusajs/medusa"
+import { PaymentSession } from "@medusajs/client-types"
 import Button from "@modules/common/components/button"
 import Spinner from "@modules/common/icons/spinner"
 import { OnApproveActions, OnApproveData } from "@paypal/paypal-js"
@@ -68,7 +68,7 @@ const StripePaymentButton = ({
   const [disabled, setDisabled] = useState(false)
   const [submitting, setSubmitting] = useState(false)
   const [errorMessage, setErrorMessage] = useState<string | undefined>(
-    undefined
+    undefined,
   )
 
   const { cart } = useCart()
@@ -111,7 +111,7 @@ const StripePaymentButton = ({
               postal_code: cart.billing_address.postal_code ?? undefined,
               state: cart.billing_address.province ?? undefined,
             },
-            email: cart.email,
+            email: cart.email ?? undefined,
             phone: cart.billing_address.phone ?? undefined,
           },
         },
@@ -173,7 +173,7 @@ const PayPalPaymentButton = ({
 }) => {
   const [submitting, setSubmitting] = useState(false)
   const [errorMessage, setErrorMessage] = useState<string | undefined>(
-    undefined
+    undefined,
   )
 
   const { cart } = useCart()
@@ -181,7 +181,7 @@ const PayPalPaymentButton = ({
 
   const handlePayment = async (
     _data: OnApproveData,
-    actions: OnApproveActions
+    actions: OnApproveActions,
   ) => {
     actions?.order
       ?.authorize()

--- a/src/modules/checkout/components/payment-container/index.tsx
+++ b/src/modules/checkout/components/payment-container/index.tsx
@@ -1,4 +1,4 @@
-import { PaymentSession } from "@medusajs/medusa"
+import { PaymentSession } from "@medusajs/client-types"
 import Radio from "@modules/common/components/radio"
 import clsx from "clsx"
 import React from "react"
@@ -43,7 +43,7 @@ const PaymentContainer: React.FC<PaymentContainerProps> = ({
         "flex flex-col gap-y-4 border-b border-gray-200 last:border-b-0",
         {
           "bg-gray-50": selected,
-        }
+        },
       )}
     >
       <button

--- a/src/modules/checkout/components/payment-container/index.tsx
+++ b/src/modules/checkout/components/payment-container/index.tsx
@@ -43,7 +43,7 @@ const PaymentContainer: React.FC<PaymentContainerProps> = ({
         "flex flex-col gap-y-4 border-b border-gray-200 last:border-b-0",
         {
           "bg-gray-50": selected,
-        },
+        }
       )}
     >
       <button

--- a/src/modules/checkout/components/payment-wrapper/index.tsx
+++ b/src/modules/checkout/components/payment-wrapper/index.tsx
@@ -1,4 +1,4 @@
-import { PaymentSession } from "@medusajs/medusa"
+import { PaymentSession } from "@medusajs/client-types"
 import { Elements } from "@stripe/react-stripe-js"
 import { loadStripe, StripeElementsOptions } from "@stripe/stripe-js"
 import React from "react"

--- a/src/modules/checkout/components/shipping/index.tsx
+++ b/src/modules/checkout/components/shipping/index.tsx
@@ -65,9 +65,9 @@ const Shipping: React.FC<ShippingProps> = ({ cart }) => {
               message:
                 "An error occurred while adding shipping. Please try again.",
             },
-            { shouldFocus: true },
+            { shouldFocus: true }
           ),
-      },
+      }
     )
   }
 
@@ -126,7 +126,7 @@ const Shipping: React.FC<ShippingProps> = ({ cart }) => {
                           "flex items-center justify-between text-small-regular cursor-pointer py-4 border-b border-gray-200 last:border-b-0 px-8",
                           {
                             "bg-gray-50": option.value === value,
-                          },
+                          }
                         )}
                       >
                         <div className="flex items-center gap-x-4">

--- a/src/modules/checkout/components/shipping/index.tsx
+++ b/src/modules/checkout/components/shipping/index.tsx
@@ -1,7 +1,7 @@
 import { RadioGroup } from "@headlessui/react"
 import { ErrorMessage } from "@hookform/error-message"
 import { useCheckout } from "@lib/context/checkout-context"
-import { Cart } from "@medusajs/medusa"
+import { Cart, SetRelation } from "@medusajs/client-types"
 import Radio from "@modules/common/components/radio"
 import Spinner from "@modules/common/icons/spinner"
 import clsx from "clsx"
@@ -16,8 +16,10 @@ type ShippingOption = {
   price: string
 }
 
+type CartWithRegion = SetRelation<Cart, "region">
+
 type ShippingProps = {
-  cart: Omit<Cart, "refundable_amount" | "refunded_total">
+  cart: CartWithRegion
 }
 
 type ShippingFormProps = {
@@ -63,9 +65,9 @@ const Shipping: React.FC<ShippingProps> = ({ cart }) => {
               message:
                 "An error occurred while adding shipping. Please try again.",
             },
-            { shouldFocus: true }
+            { shouldFocus: true },
           ),
-      }
+      },
     )
   }
 
@@ -124,7 +126,7 @@ const Shipping: React.FC<ShippingProps> = ({ cart }) => {
                           "flex items-center justify-between text-small-regular cursor-pointer py-4 border-b border-gray-200 last:border-b-0 px-8",
                           {
                             "bg-gray-50": option.value === value,
-                          }
+                          },
                         )}
                       >
                         <div className="flex items-center gap-x-4">

--- a/src/modules/common/components/cart-totals/index.tsx
+++ b/src/modules/common/components/cart-totals/index.tsx
@@ -1,9 +1,11 @@
-import { Cart } from "@medusajs/medusa"
+import { Cart, SetRelation } from "@medusajs/client-types"
 import { formatAmount } from "medusa-react"
 import React from "react"
 
+type CartWithRegion = SetRelation<Cart, "region">
+
 type CartTotalsProps = {
-  cart: Omit<Cart, "refundable_amount" | "refunded_total">
+  cart: CartWithRegion
 }
 
 const CartTotals: React.FC<CartTotalsProps> = ({ cart }) => {

--- a/src/modules/common/components/line-item-options/index.tsx
+++ b/src/modules/common/components/line-item-options/index.tsx
@@ -1,13 +1,15 @@
-import { ProductVariant } from "@medusajs/medusa"
+import { ProductVariant, SetRelation } from "@medusajs/client-types"
 
-type LineItemOptionsProps = { variant: ProductVariant }
+type ProductVariantWithOptionsWithProduct = SetRelation<ProductVariant, "product">
+
+type LineItemOptionsProps = { variant: ProductVariantWithOptionsWithProduct }
 
 const LineItemOptions = ({ variant }: LineItemOptionsProps) => {
   return (
     <div className="text-small-regular text-gray-700">
-      {variant.options.map((option) => {
+      {(variant.options ?? []).map((option) => {
         const optionName =
-          variant.product.options.find((opt) => opt.id === option.option_id)
+          variant.product?.options?.find((opt) => opt.id === option.option_id)
             ?.title || "Option"
         return (
           <div key={option.id}>

--- a/src/modules/common/components/line-item-price/index.tsx
+++ b/src/modules/common/components/line-item-price/index.tsx
@@ -1,5 +1,5 @@
 import { getPercentageDiff } from "@lib/util/get-precentage-diff"
-import { LineItem, Region } from "@medusajs/medusa"
+import { LineItem, Region } from "@medusajs/client-types"
 import clsx from "clsx"
 import { formatAmount } from "medusa-react"
 import { CalculatedVariant } from "types/medusa"

--- a/src/modules/order/components/items/index.tsx
+++ b/src/modules/order/components/items/index.tsx
@@ -20,37 +20,37 @@ const Items = ({ items, region, cartId }: ItemsProps) => {
     <div className="p-10 border-b border-gray-200 gap-y-4 flex flex-col">
       {enrichedItems?.length
         ? enrichedItems.map((item) => {
-          return (
-            <div className="grid grid-cols-[122px_1fr] gap-x-4" key={item.id}>
-              <div className="w-[122px]">
-                <Thumbnail thumbnail={item.thumbnail} size="full" />
-              </div>
-              <div className="flex flex-col justify-between flex-1">
-                <div className="flex flex-col flex-1 text-small-regular">
-                  <div className="flex items-start justify-between">
-                    <div>
-                      <h3 className="text-base-regular overflow-ellipsis overflow-hidden whitespace-nowrap mr-4">
-                        <Link
-                          href={`/products/${item.variant.product.handle}`}
-                        >
-                          <a>{item.title}</a>
-                        </Link>
-                      </h3>
-                      <LineItemOptions variant={item.variant} />
-                      <span>Quantity: {item.quantity}</span>
-                    </div>
-                    <div className="flex justify-end">
-                      <LineItemPrice region={region} item={item} />
+            return (
+              <div className="grid grid-cols-[122px_1fr] gap-x-4" key={item.id}>
+                <div className="w-[122px]">
+                  <Thumbnail thumbnail={item.thumbnail} size="full" />
+                </div>
+                <div className="flex flex-col justify-between flex-1">
+                  <div className="flex flex-col flex-1 text-small-regular">
+                    <div className="flex items-start justify-between">
+                      <div>
+                        <h3 className="text-base-regular overflow-ellipsis overflow-hidden whitespace-nowrap mr-4">
+                          <Link
+                            href={`/products/${item.variant.product.handle}`}
+                          >
+                            <a>{item.title}</a>
+                          </Link>
+                        </h3>
+                        <LineItemOptions variant={item.variant} />
+                        <span>Quantity: {item.quantity}</span>
+                      </div>
+                      <div className="flex justify-end">
+                        <LineItemPrice region={region} item={item} />
+                      </div>
                     </div>
                   </div>
                 </div>
               </div>
-            </div>
-          )
-        })
+            )
+          })
         : Array.from(Array(items.length).keys()).map((i) => {
-          return <SkeletonLineItem key={i} />
-        })}
+            return <SkeletonLineItem key={i} />
+          })}
     </div>
   )
 }

--- a/src/modules/order/components/items/index.tsx
+++ b/src/modules/order/components/items/index.tsx
@@ -1,15 +1,16 @@
 import useEnrichedLineItems from "@lib/hooks/use-enrich-line-items"
-import { LineItem, Region } from "@medusajs/medusa"
+import { Region } from "@medusajs/client-types"
 import LineItemOptions from "@modules/common/components/line-item-options"
 import LineItemPrice from "@modules/common/components/line-item-price"
 import Thumbnail from "@modules/products/components/thumbnail"
 import SkeletonLineItem from "@modules/skeletons/components/skeleton-line-item"
 import Link from "next/link"
+import { LineItemWithRelations } from "../../../../types/medusa"
 
 type ItemsProps = {
-  items: LineItem[]
+  items: LineItemWithRelations[]
   region: Region
-  cartId: string
+  cartId?: string
 }
 
 const Items = ({ items, region, cartId }: ItemsProps) => {
@@ -19,37 +20,37 @@ const Items = ({ items, region, cartId }: ItemsProps) => {
     <div className="p-10 border-b border-gray-200 gap-y-4 flex flex-col">
       {enrichedItems?.length
         ? enrichedItems.map((item) => {
-            return (
-              <div className="grid grid-cols-[122px_1fr] gap-x-4" key={item.id}>
-                <div className="w-[122px]">
-                  <Thumbnail thumbnail={item.thumbnail} size="full" />
-                </div>
-                <div className="flex flex-col justify-between flex-1">
-                  <div className="flex flex-col flex-1 text-small-regular">
-                    <div className="flex items-start justify-between">
-                      <div>
-                        <h3 className="text-base-regular overflow-ellipsis overflow-hidden whitespace-nowrap mr-4">
-                          <Link
-                            href={`/products/${item.variant.product.handle}`}
-                          >
-                            <a>{item.title}</a>
-                          </Link>
-                        </h3>
-                        <LineItemOptions variant={item.variant} />
-                        <span>Quantity: {item.quantity}</span>
-                      </div>
-                      <div className="flex justify-end">
-                        <LineItemPrice region={region} item={item} />
-                      </div>
+          return (
+            <div className="grid grid-cols-[122px_1fr] gap-x-4" key={item.id}>
+              <div className="w-[122px]">
+                <Thumbnail thumbnail={item.thumbnail} size="full" />
+              </div>
+              <div className="flex flex-col justify-between flex-1">
+                <div className="flex flex-col flex-1 text-small-regular">
+                  <div className="flex items-start justify-between">
+                    <div>
+                      <h3 className="text-base-regular overflow-ellipsis overflow-hidden whitespace-nowrap mr-4">
+                        <Link
+                          href={`/products/${item.variant.product.handle}`}
+                        >
+                          <a>{item.title}</a>
+                        </Link>
+                      </h3>
+                      <LineItemOptions variant={item.variant} />
+                      <span>Quantity: {item.quantity}</span>
+                    </div>
+                    <div className="flex justify-end">
+                      <LineItemPrice region={region} item={item} />
                     </div>
                   </div>
                 </div>
               </div>
-            )
-          })
+            </div>
+          )
+        })
         : Array.from(Array(items.length).keys()).map((i) => {
-            return <SkeletonLineItem key={i} />
-          })}
+          return <SkeletonLineItem key={i} />
+        })}
     </div>
   )
 }

--- a/src/modules/order/components/order-details/index.tsx
+++ b/src/modules/order/components/order-details/index.tsx
@@ -1,7 +1,9 @@
-import { Order } from "@medusajs/medusa"
+import { Order, SetRelation } from "@medusajs/client-types"
+
+type OrderWithItems = SetRelation<Order, "items">
 
 type OrderDetailsProps = {
-  order: Order
+  order: OrderWithItems
   showStatus?: boolean
 }
 

--- a/src/modules/order/components/order-summary/index.tsx
+++ b/src/modules/order/components/order-summary/index.tsx
@@ -1,8 +1,10 @@
-import { Order } from "@medusajs/medusa"
+import { Order, SetRelation } from "@medusajs/client-types"
 import { formatAmount } from "medusa-react"
 
+type OrderWithRegionWithDiscountTotalWithGiftCardTotal = SetRelation<Order, "region" | "discount_total" | "gift_card_total">
+
 type OrderSummaryProps = {
-  order: Order
+  order: OrderWithRegionWithDiscountTotalWithGiftCardTotal
 }
 
 const OrderSummary = ({ order }: OrderSummaryProps) => {

--- a/src/modules/order/components/shipping-details/index.tsx
+++ b/src/modules/order/components/shipping-details/index.tsx
@@ -1,8 +1,10 @@
-import { Address, ShippingMethod } from "@medusajs/medusa"
+import { Address, SetRelation, ShippingMethod } from "@medusajs/client-types"
+
+type ShippingMethodWithShippingOption = SetRelation<ShippingMethod, "shipping_option">
 
 type ShippingDetailsProps = {
   address: Address
-  shippingMethods: ShippingMethod[]
+  shippingMethods: ShippingMethodWithShippingOption[]
 }
 
 const ShippingDetails = ({

--- a/src/modules/order/templates/order-completed-template.tsx
+++ b/src/modules/order/templates/order-completed-template.tsx
@@ -1,13 +1,13 @@
-import { Order } from "@medusajs/medusa"
 import Help from "@modules/order/components/help"
 import Items from "@modules/order/components/items"
 import OrderDetails from "@modules/order/components/order-details"
 import OrderSummary from "@modules/order/components/order-summary"
 import ShippingDetails from "@modules/order/components/shipping-details"
 import React from "react"
+import { OrderWithRelations } from "types/medusa"
 
 type OrderCompletedTemplateProps = {
-  order: Order
+  order: OrderWithRelations
 }
 
 const OrderCompletedTemplate: React.FC<OrderCompletedTemplateProps> = ({
@@ -21,7 +21,7 @@ const OrderCompletedTemplate: React.FC<OrderCompletedTemplateProps> = ({
           <Items
             items={order.items}
             region={order.region}
-            cartId={order.cart_id}
+            cartId={order.cart_id ?? undefined}
           />
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 p-10 border-b border-gray-200">
             <ShippingDetails

--- a/src/modules/order/templates/order-details-template.tsx
+++ b/src/modules/order/templates/order-details-template.tsx
@@ -1,13 +1,13 @@
-import { Order } from "@medusajs/medusa"
 import Help from "@modules/order/components/help"
 import Items from "@modules/order/components/items"
 import OrderDetails from "@modules/order/components/order-details"
 import OrderSummary from "@modules/order/components/order-summary"
 import ShippingDetails from "@modules/order/components/shipping-details"
 import React from "react"
+import { OrderWithRelations } from "../../../types/medusa"
 
 type OrderDetailsTemplateProps = {
-  order: Order
+  order: OrderWithRelations
 }
 
 const OrderDetailsTemplate: React.FC<OrderDetailsTemplateProps> = ({
@@ -21,7 +21,7 @@ const OrderDetailsTemplate: React.FC<OrderDetailsTemplateProps> = ({
           <Items
             items={order.items}
             region={order.region}
-            cartId={order.cart_id}
+            cartId={order.cart_id ?? undefined}
           />
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 p-10 border-b border-gray-200">
             <ShippingDetails

--- a/src/modules/products/components/image-gallary/index.tsx
+++ b/src/modules/products/components/image-gallary/index.tsx
@@ -1,4 +1,4 @@
-import { Image as MedusaImage } from "@medusajs/medusa"
+import { Image as MedusaImage } from "@medusajs/client-types"
 import Image from "next/image"
 import { useRef } from "react"
 

--- a/src/modules/products/components/infinite-products/index.tsx
+++ b/src/modules/products/components/infinite-products/index.tsx
@@ -2,7 +2,7 @@ import { fetchProductsList } from "@lib/data"
 import usePreviews from "@lib/hooks/use-previews"
 import getNumberOfSkeletons from "@lib/util/get-number-of-skeletons"
 import repeat from "@lib/util/repeat"
-import { StoreGetProductsParams } from "@medusajs/medusa"
+import { StoreGetProductsParams } from "@medusajs/client-types"
 import ProductPreview from "@modules/products/components/product-preview"
 import SkeletonProductPreview from "@modules/skeletons/components/skeleton-product-preview"
 import { useCart } from "medusa-react"
@@ -40,7 +40,7 @@ const InfiniteProducts = ({ params }: InfiniteProductsType) => {
       ({ pageParam }) => fetchProductsList({ pageParam, queryParams }),
       {
         getNextPageParam: (lastPage) => lastPage.nextPage,
-      }
+      },
     )
 
   const previews = usePreviews({ pages: data?.pages, region: cart?.region })

--- a/src/modules/products/components/infinite-products/index.tsx
+++ b/src/modules/products/components/infinite-products/index.tsx
@@ -40,7 +40,7 @@ const InfiniteProducts = ({ params }: InfiniteProductsType) => {
       ({ pageParam }) => fetchProductsList({ pageParam, queryParams }),
       {
         getNextPageParam: (lastPage) => lastPage.nextPage,
-      },
+      }
     )
 
   const previews = usePreviews({ pages: data?.pages, region: cart?.region })

--- a/src/modules/products/components/mobile-actions/index.tsx
+++ b/src/modules/products/components/mobile-actions/index.tsx
@@ -7,11 +7,11 @@ import ChevronDown from "@modules/common/icons/chevron-down"
 import X from "@modules/common/icons/x"
 import clsx from "clsx"
 import React, { Fragment, useMemo } from "react"
-import { Product } from "types/medusa"
 import OptionSelect from "../option-select"
+import { ProductWithVariantsWithOptions } from "types/medusa"
 
 type MobileActionsProps = {
-  product: Product
+  product: ProductWithVariantsWithOptions
   show: boolean
 }
 
@@ -44,7 +44,8 @@ const MobileActions: React.FC<MobileActionsProps> = ({ product, show }) => {
           leaveFrom="opacity-100"
           leaveTo="opacity-0"
         >
-          <div className="bg-white flex flex-col gap-y-3 justify-center items-center text-large-regular p-4 h-full w-full border-t border-gray-200">
+          <div
+            className="bg-white flex flex-col gap-y-3 justify-center items-center text-large-regular p-4 h-full w-full border-t border-gray-200">
             <div className="flex items-center gap-x-2">
               <span>{product.title}</span>
               <span>—</span>

--- a/src/modules/products/components/mobile-actions/index.tsx
+++ b/src/modules/products/components/mobile-actions/index.tsx
@@ -16,7 +16,8 @@ type MobileActionsProps = {
 }
 
 const MobileActions: React.FC<MobileActionsProps> = ({ product, show }) => {
-  const { variant, addToCart, options, inStock, updateOptions } = useProductActions()
+  const { variant, addToCart, options, inStock, updateOptions } =
+    useProductActions()
   const { state, open, close } = useToggleState()
 
   const price = useProductPrice({ id: product.id, variantId: variant?.id })
@@ -44,8 +45,7 @@ const MobileActions: React.FC<MobileActionsProps> = ({ product, show }) => {
           leaveFrom="opacity-100"
           leaveTo="opacity-0"
         >
-          <div
-            className="bg-white flex flex-col gap-y-3 justify-center items-center text-large-regular p-4 h-full w-full border-t border-gray-200">
+          <div className="bg-white flex flex-col gap-y-3 justify-center items-center text-large-regular p-4 h-full w-full border-t border-gray-200">
             <div className="flex items-center gap-x-2">
               <span>{product.title}</span>
               <span>—</span>
@@ -81,7 +81,9 @@ const MobileActions: React.FC<MobileActionsProps> = ({ product, show }) => {
                   <ChevronDown />
                 </div>
               </Button>
-              <Button onClick={addToCart}>{!inStock ? "Out of stock" : "Add to cart"}</Button>
+              <Button onClick={addToCart}>
+                {!inStock ? "Out of stock" : "Add to cart"}
+              </Button>
             </div>
           </div>
         </Transition>

--- a/src/modules/products/components/option-select/index.tsx
+++ b/src/modules/products/components/option-select/index.tsx
@@ -31,7 +31,7 @@ const OptionSelect: React.FC<OptionSelectProps> = ({
               key={v}
               className={clsx(
                 "border-gray-200 border text-xsmall-regular h-[50px] transition-all duration-200",
-                { "border-gray-900": v === current },
+                { "border-gray-900": v === current }
               )}
             >
               {v}

--- a/src/modules/products/components/option-select/index.tsx
+++ b/src/modules/products/components/option-select/index.tsx
@@ -1,10 +1,12 @@
 import { onlyUnique } from "@lib/util/only-unique"
-import { ProductOption } from "@medusajs/medusa"
+import { ProductOption, SetRelation } from "@medusajs/client-types"
 import clsx from "clsx"
 import React from "react"
 
+type ProductOptionWithValues = SetRelation<ProductOption, "values">
+
 type OptionSelectProps = {
-  option: ProductOption
+  option: ProductOptionWithValues
   current: string
   updateOption: (option: Record<string, string>) => void
   title: string
@@ -29,7 +31,7 @@ const OptionSelect: React.FC<OptionSelectProps> = ({
               key={v}
               className={clsx(
                 "border-gray-200 border text-xsmall-regular h-[50px] transition-all duration-200",
-                { "border-gray-900": v === current }
+                { "border-gray-900": v === current },
               )}
             >
               {v}

--- a/src/modules/products/components/product-actions/index.tsx
+++ b/src/modules/products/components/product-actions/index.tsx
@@ -5,10 +5,10 @@ import OptionSelect from "@modules/products/components/option-select"
 import clsx from "clsx"
 import Link from "next/link"
 import React, { useMemo } from "react"
-import { Product } from "types/medusa"
+import { ProductWithVariantsWithOptions } from "types/medusa"
 
 type ProductActionsProps = {
-  product: Product
+  product: ProductWithVariantsWithOptions
 }
 
 const ProductActions: React.FC<ProductActionsProps> = ({ product }) => {

--- a/src/modules/products/components/product-tabs/index.tsx
+++ b/src/modules/products/components/product-tabs/index.tsx
@@ -39,7 +39,7 @@ const ProductTabs = ({ product }: ProductTabsProps) => {
                     "text-left uppercase text-small-regular pb-2 -mb-px border-b border-gray-200 transition-color duration-150 ease-in-out",
                     {
                       "border-b border-gray-900": selected,
-                    },
+                    }
                   )
                 }
               >

--- a/src/modules/products/components/product-tabs/index.tsx
+++ b/src/modules/products/components/product-tabs/index.tsx
@@ -1,13 +1,15 @@
 import { Tab } from "@headlessui/react"
-import { Product } from "@medusajs/medusa"
+import { Product, SetRelation } from "@medusajs/client-types"
 import Back from "@modules/common/icons/back"
 import FastDelivery from "@modules/common/icons/fast-delivery"
 import Refresh from "@modules/common/icons/refresh"
 import clsx from "clsx"
 import { useMemo } from "react"
 
+type ProductWithTags = SetRelation<Product, "tags">
+
 type ProductTabsProps = {
-  product: Product
+  product: ProductWithTags
 }
 
 const ProductTabs = ({ product }: ProductTabsProps) => {
@@ -37,7 +39,7 @@ const ProductTabs = ({ product }: ProductTabsProps) => {
                     "text-left uppercase text-small-regular pb-2 -mb-px border-b border-gray-200 transition-color duration-150 ease-in-out",
                     {
                       "border-b border-gray-900": selected,
-                    }
+                    },
                   )
                 }
               >

--- a/src/modules/products/components/related-products/index.tsx
+++ b/src/modules/products/components/related-products/index.tsx
@@ -2,7 +2,7 @@ import { fetchProductsList } from "@lib/data"
 import usePreviews from "@lib/hooks/use-previews"
 import getNumberOfSkeletons from "@lib/util/get-number-of-skeletons"
 import repeat from "@lib/util/repeat"
-import { Product, StoreGetProductsParams } from "@medusajs/medusa"
+import { Product, StoreGetProductsParams } from "@medusajs/client-types"
 import Button from "@modules/common/components/button"
 import SkeletonProductPreview from "@modules/skeletons/components/skeleton-product-preview"
 import { useCart } from "medusa-react"
@@ -43,7 +43,7 @@ const RelatedProducts = ({ product }: RelatedProductsProps) => {
       ({ pageParam }) => fetchProductsList({ pageParam, queryParams }),
       {
         getNextPageParam: (lastPage) => lastPage.nextPage,
-      }
+      },
     )
 
   const previews = usePreviews({ pages: data?.pages, region: cart?.region })

--- a/src/modules/products/components/related-products/index.tsx
+++ b/src/modules/products/components/related-products/index.tsx
@@ -43,7 +43,7 @@ const RelatedProducts = ({ product }: RelatedProductsProps) => {
       ({ pageParam }) => fetchProductsList({ pageParam, queryParams }),
       {
         getNextPageParam: (lastPage) => lastPage.nextPage,
-      },
+      }
     )
 
   const previews = usePreviews({ pages: data?.pages, region: cart?.region })

--- a/src/modules/products/components/thumbnail/index.tsx
+++ b/src/modules/products/components/thumbnail/index.tsx
@@ -1,4 +1,4 @@
-import { Image as MedusaImage } from "@medusajs/medusa"
+import { Image as MedusaImage } from "@medusajs/client-types"
 import PlaceholderImage from "@modules/common/icons/placeholder-image"
 import clsx from "clsx"
 import Image from "next/image"

--- a/src/modules/products/templates/index.tsx
+++ b/src/modules/products/templates/index.tsx
@@ -1,15 +1,15 @@
 import { ProductProvider } from "@lib/context/product-context"
 import { useIntersection } from "@lib/hooks/use-in-view"
-import { Product } from "@medusajs/medusa"
 import ProductTabs from "@modules/products/components/product-tabs"
 import RelatedProducts from "@modules/products/components/related-products"
 import ProductInfo from "@modules/products/templates/product-info"
 import React, { useRef } from "react"
 import ImageGallery from "../components/image-gallary"
 import MobileActions from "../components/mobile-actions"
+import { ProductWithRelations } from "../../../types/medusa"
 
 type ProductTemplateProps = {
-  product: Product
+  product: ProductWithRelations
 }
 
 const ProductTemplate: React.FC<ProductTemplateProps> = ({ product }) => {

--- a/src/modules/products/templates/product-info/index.tsx
+++ b/src/modules/products/templates/product-info/index.tsx
@@ -1,9 +1,9 @@
 import ProductActions from "@modules/products/components/product-actions"
 import React from "react"
-import { Product } from "types/medusa"
+import { ProductWithVariantsWithOptions } from "types/medusa"
 
 type ProductInfoProps = {
-  product: Product
+  product: ProductWithVariantsWithOptions
 }
 
 const ProductInfo: React.FC<ProductInfoProps> = ({ product }) => {

--- a/src/modules/search/components/hit/index.tsx
+++ b/src/modules/search/components/hit/index.tsx
@@ -1,4 +1,4 @@
-import { ProductVariant } from "@medusajs/medusa"
+import { ProductVariant } from "@medusajs/client-types"
 import Thumbnail from "@modules/products/components/thumbnail"
 import Link from "next/link"
 

--- a/src/modules/store/components/refinement-list/index.tsx
+++ b/src/modules/store/components/refinement-list/index.tsx
@@ -15,7 +15,7 @@ const RefinementList = ({
 
   const handleCollectionChange = (
     e: ChangeEvent<HTMLInputElement>,
-    id: string,
+    id: string
   ) => {
     const { checked } = e.target
 
@@ -56,7 +56,7 @@ const RefinementList = ({
                   <input
                     type="checkbox"
                     defaultChecked={refinementList.collection_id?.includes(
-                      c.id,
+                      c.id
                     )}
                     onChange={(e) => handleCollectionChange(e, c.id)}
                     className="accent-amber-200"

--- a/src/modules/store/components/refinement-list/index.tsx
+++ b/src/modules/store/components/refinement-list/index.tsx
@@ -1,4 +1,4 @@
-import { StoreGetProductsParams } from "@medusajs/medusa"
+import { StoreGetProductsParams } from "@medusajs/client-types"
 import { useCollections } from "medusa-react"
 import { ChangeEvent } from "react"
 
@@ -15,7 +15,7 @@ const RefinementList = ({
 
   const handleCollectionChange = (
     e: ChangeEvent<HTMLInputElement>,
-    id: string
+    id: string,
   ) => {
     const { checked } = e.target
 
@@ -56,7 +56,7 @@ const RefinementList = ({
                   <input
                     type="checkbox"
                     defaultChecked={refinementList.collection_id?.includes(
-                      c.id
+                      c.id,
                     )}
                     onChange={(e) => handleCollectionChange(e, c.id)}
                     className="accent-amber-200"

--- a/src/pages/store.tsx
+++ b/src/pages/store.tsx
@@ -1,4 +1,4 @@
-import { StoreGetProductsParams } from "@medusajs/medusa"
+import { StoreGetProductsParams } from "@medusajs/client-types"
 import Head from "@modules/common/components/head"
 import Layout from "@modules/layout/templates"
 import InfiniteProducts from "@modules/products/components/infinite-products"

--- a/src/types/global.ts
+++ b/src/types/global.ts
@@ -1,4 +1,4 @@
-import { Product } from "@medusajs/medusa"
+import { Product } from "@medusajs/client-types"
 import { NextPage } from "next"
 import { AppProps } from "next/app"
 import { ReactElement, ReactNode } from "react"

--- a/src/types/medusa.ts
+++ b/src/types/medusa.ts
@@ -1,19 +1,46 @@
 import {
-  Product as MedusaProduct,
+  LineItem,
+  Merge,
+  Order,
+  Product,
+  ProductOption,
   ProductVariant,
-  Region as MedusaRegion,
-} from "@medusajs/medusa"
+  SetRelation,
+  ShippingMethod,
+} from "@medusajs/client-types"
 
-export type Variant = Omit<ProductVariant, "beforeInsert">
-
-export interface Product extends Omit<MedusaProduct, "variants"> {
-  variants: Variant[]
-}
-
-export interface Region extends Omit<MedusaRegion, "beforeInsert"> {}
+export type ProductWithVariantsWithOptions = Merge<SetRelation<Product, "variants" | "options">, {
+  options: Array<SetRelation<ProductOption, "values">>
+}>
 
 export type CalculatedVariant = ProductVariant & {
   calculated_price: number
   calculated_price_type: "sale" | "default"
   original_price: number
 }
+
+/**
+ * Subset of default relations from StoreCartsRes["order"] and StoreOrdersRes["order"]
+ */
+export type OrderWithRelations =
+  Merge<SetRelation<Order, "items" | "region" | "shipping_methods" | "shipping_address" | "discount_total" | "gift_card_total">, {
+    items: Array<Merge<SetRelation<LineItem, "variant">, {
+      variant: SetRelation<ProductVariant, "product">
+    }>>
+    shipping_methods: Array<SetRelation<ShippingMethod, "shipping_option">>
+  }>
+
+/**
+ * Subset of default relations from StoreCartsRes["order"]["items"] and StoreOrdersRes["order"]["items"]
+ */
+export type LineItemWithRelations = Merge<SetRelation<LineItem, "variant">, {
+  variant: SetRelation<ProductVariant, "product">
+}>
+
+/**
+ * Subset of default relations from StoreProductsListRes["products"]
+ */
+export type ProductWithRelations = Merge<SetRelation<Product, "variants" | "options" | "images" | "tags">, {
+  variants: Array<SetRelation<ProductVariant, "options" | "prices">>
+  options: Array<SetRelation<ProductOption, "values">>
+}>

--- a/src/types/medusa.ts
+++ b/src/types/medusa.ts
@@ -9,9 +9,12 @@ import {
   ShippingMethod,
 } from "@medusajs/client-types"
 
-export type ProductWithVariantsWithOptions = Merge<SetRelation<Product, "variants" | "options">, {
-  options: Array<SetRelation<ProductOption, "values">>
-}>
+export type ProductWithVariantsWithOptions = Merge<
+  SetRelation<Product, "variants" | "options">,
+  {
+    options: Array<SetRelation<ProductOption, "values">>
+  }
+>
 
 export type CalculatedVariant = ProductVariant & {
   calculated_price: number
@@ -22,25 +25,46 @@ export type CalculatedVariant = ProductVariant & {
 /**
  * Subset of default relations from StoreCartsRes["order"] and StoreOrdersRes["order"]
  */
-export type OrderWithRelations =
-  Merge<SetRelation<Order, "items" | "region" | "shipping_methods" | "shipping_address" | "discount_total" | "gift_card_total">, {
-    items: Array<Merge<SetRelation<LineItem, "variant">, {
-      variant: SetRelation<ProductVariant, "product">
-    }>>
+export type OrderWithRelations = Merge<
+  SetRelation<
+    Order,
+    | "items"
+    | "region"
+    | "shipping_methods"
+    | "shipping_address"
+    | "discount_total"
+    | "gift_card_total"
+  >,
+  {
+    items: Array<
+      Merge<
+        SetRelation<LineItem, "variant">,
+        {
+          variant: SetRelation<ProductVariant, "product">
+        }
+      >
+    >
     shipping_methods: Array<SetRelation<ShippingMethod, "shipping_option">>
-  }>
+  }
+>
 
 /**
  * Subset of default relations from StoreCartsRes["order"]["items"] and StoreOrdersRes["order"]["items"]
  */
-export type LineItemWithRelations = Merge<SetRelation<LineItem, "variant">, {
-  variant: SetRelation<ProductVariant, "product">
-}>
+export type LineItemWithRelations = Merge<
+  SetRelation<LineItem, "variant">,
+  {
+    variant: SetRelation<ProductVariant, "product">
+  }
+>
 
 /**
  * Subset of default relations from StoreProductsListRes["products"]
  */
-export type ProductWithRelations = Merge<SetRelation<Product, "variants" | "options" | "images" | "tags">, {
-  variants: Array<SetRelation<ProductVariant, "options" | "prices">>
-  options: Array<SetRelation<ProductOption, "values">>
-}>
+export type ProductWithRelations = Merge<
+  SetRelation<Product, "variants" | "options" | "images" | "tags">,
+  {
+    variants: Array<SetRelation<ProductVariant, "options" | "prices">>
+    options: Array<SetRelation<ProductOption, "values">>
+  }
+>

--- a/yarn.lock
+++ b/yarn.lock
@@ -446,6 +446,18 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
+"@hapi/hoek@^9.0.0":
+  version "9.3.0"
+  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.3.0.tgz#8368869dcb735be2e7f5cb7647de78e167a251fb"
+  integrity sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==
+
+"@hapi/topo@^5.0.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@hapi/topo/-/topo-5.1.0.tgz#dc448e332c6c6e37a4dc02fd84ba8d44b9afb012"
+  integrity sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+
 "@headlessui/react@^1.6.1":
   version "1.7.7"
   resolved "https://registry.yarnpkg.com/@headlessui/react/-/react-1.7.7.tgz#d6f8708d8943ae8ebb1a6929108234e4515ac7e8"
@@ -535,15 +547,15 @@
     semver "^7.3.5"
     tar "^6.1.11"
 
-"@medusajs/client-types@0.1.0-dev-1679077162720":
-  version "0.1.0-dev-1679077162720"
-  resolved "http://localhost:4873/@medusajs%2fclient-types/-/client-types-0.1.0-dev-1679077162720.tgz#49955f6aa72bda89512be9037c0f06008e46c3b8"
-  integrity sha512-FnPODgx0gOzMyFq+uIBNLXw3s7v9Hiwd6AJgDnALnXO7L6RXLXEbSWTb39LOgVdQXISsrze4yFgFNAkVpNwraw==
+"@medusajs/client-types@0.2.0-snapshot-20230320172940":
+  version "0.2.0-snapshot-20230320172940"
+  resolved "https://registry.yarnpkg.com/@medusajs/client-types/-/client-types-0.2.0-snapshot-20230320172940.tgz#c3f1accc646508299da8254703a3f6b4c0842c15"
+  integrity sha512-ZEFbDrK6LHYGd+zDW+5Li27hiVQPnbh0rX5fVvQXTKVn7tlg/VPcwBg2p2dASvrHhQYY9f9T2vTczYr/a3XLxg==
 
-"@medusajs/medusa-cli@1.3.8-dev-1679077162720":
-  version "1.3.8-dev-1679077162720"
-  resolved "http://localhost:4873/@medusajs%2fmedusa-cli/-/medusa-cli-1.3.8-dev-1679077162720.tgz#a7e11b706841319008d0e7d635b0f7d869ca085c"
-  integrity sha512-HBaDMhSS2K8bbj/olzDtu4FvEtCxO+yuuoUUtuR3ZnqTucrDVgKyJrQwc+lcdNs6P7dq8HKuHybUmmJ8VLwNdg==
+"@medusajs/medusa-cli@^1.3.8":
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/@medusajs/medusa-cli/-/medusa-cli-1.3.8.tgz#1cbf31e921819cab2a53f07fe80772e03855f64e"
+  integrity sha512-jmAzJbTnQC9P/ZDQT4+8hYfeDuozpm1YPu+gZJLPf/ZanjJLWb6QKy6g0Smru6MlOw0dK5iHEZYXkZpiqNUATQ==
   dependencies:
     "@babel/polyfill" "^7.8.7"
     "@babel/runtime" "^7.9.6"
@@ -559,8 +571,8 @@
     inquirer "^8.0.0"
     is-valid-path "^0.1.1"
     meant "^1.0.3"
-    medusa-core-utils "1.1.39-dev-1679077162720"
-    medusa-telemetry "0.0.16-dev-1679077162720"
+    medusa-core-utils "^1.1.39"
+    medusa-telemetry "0.0.16"
     netrc-parser "^3.1.6"
     open "^8.0.6"
     ora "^5.4.1"
@@ -574,43 +586,23 @@
     winston "^3.8.2"
     yargs "^15.3.1"
 
-"@medusajs/medusa-client-admin@0.1.0-dev-1679077162720":
-  version "0.1.0-dev-1679077162720"
-  resolved "http://localhost:4873/@medusajs%2fmedusa-client-admin/-/medusa-client-admin-0.1.0-dev-1679077162720.tgz#bcb9cd3f030bcc46ea87100c939cdb5760bd9e8f"
-  integrity sha512-1CbM8xCS7bq9a7EJJrD4Cv/gRND1WF5JagTUhITN3e/OD6dP9e4DDDu3q/1qBfBXLtU2VIsJUM7QrSIRy/HxmQ==
-  dependencies:
-    "@medusajs/client-types" "0.1.0-dev-1679077162720"
-    axios "^1.2.0"
-    form-data "^4.0.0"
-    node-fetch "2.6.7"
-
-"@medusajs/medusa-client-store@0.1.0-dev-1679077162720":
-  version "0.1.0-dev-1679077162720"
-  resolved "http://localhost:4873/@medusajs%2fmedusa-client-store/-/medusa-client-store-0.1.0-dev-1679077162720.tgz#2c6eab2e5958b51e88396fee80ea1c1d0218cb84"
-  integrity sha512-azbX/tpqKmtWohNHxXDADGtX4Hs9FuehCwyL/yQURjC9ZbMc9RRK6ohpnFymN5wpePR+BEZEd9PKwEWWI0J94A==
-  dependencies:
-    "@medusajs/client-types" "0.1.0-dev-1679077162720"
-    axios "^1.2.0"
-    form-data "^4.0.0"
-    node-fetch "2.6.7"
-
-"@medusajs/medusa-js@1.3.10-dev-1679077162720":
-  version "1.3.10-dev-1679077162720"
-  resolved "http://localhost:4873/@medusajs%2fmedusa-js/-/medusa-js-1.3.10-dev-1679077162720.tgz#88d4cd1ace983a7efb1c4789dfd5db7576b6d7c0"
-  integrity sha512-eTLRug3dWnurbb27ChCnAHXPscUpZaZwUDllcaOXvvVirCBePjKwLX5ei6hsgytZqyNP3A+vc+Tszrn2jLSACA==
+"@medusajs/medusa-js@2.0.0-snapshot-20230320172940":
+  version "2.0.0-snapshot-20230320172940"
+  resolved "https://registry.yarnpkg.com/@medusajs/medusa-js/-/medusa-js-2.0.0-snapshot-20230320172940.tgz#a2089cbf1e01c295e3183152e03ef2881a1f02e2"
+  integrity sha512-/OVIqE2lFKXts9ol+e8qTXTu+8kNuOtTf4GCR1n5Pbc8QVZlDAQwn2tPkmVW/gUJVfLxVaJvmm8vkgvDPtmdMg==
   dependencies:
     axios "^0.24.0"
     qs "^6.10.3"
     retry-axios "^2.6.0"
     uuid "^9.0.0"
 
-"@medusajs/medusa@1.7.13-dev-1679077162720":
-  version "1.7.13-dev-1679077162720"
-  resolved "http://localhost:4873/@medusajs%2fmedusa/-/medusa-1.7.13-dev-1679077162720.tgz#dcd19416fd37917c24be23fd3f2be246bfda8c23"
-  integrity sha512-f7vFCei8cqhyC1PHCYCuB5ATOO9Xxyx3fwKBKIDaTyQHCYKg06wLudhDMy0gghzNCxC8D/xEk5FlnLDPqUsLKg==
+"@medusajs/medusa@2.0.0-snapshot-20230320172940":
+  version "2.0.0-snapshot-20230320172940"
+  resolved "https://registry.yarnpkg.com/@medusajs/medusa/-/medusa-2.0.0-snapshot-20230320172940.tgz#a7bc9abcf3ddc2c8069716ea99bc5c5a6ce14371"
+  integrity sha512-PGNiFFrpH3mZT0HlarYHXZ8tSj5S36HTMWHxxqtzNedl2XyV6/M0uRFLYc0RbUEDczb84aheGTEMze2+ACrZJQ==
   dependencies:
-    "@medusajs/medusa-cli" "1.3.8-dev-1679077162720"
-    "@medusajs/modules-sdk" "0.0.1-dev-1679077162720"
+    "@medusajs/medusa-cli" "^1.3.8"
+    "@medusajs/modules-sdk" "0.1.0-snapshot-20230320172940"
     "@types/ioredis" "^4.28.10"
     "@types/lodash" "^4.14.191"
     awilix "^8.0.0"
@@ -632,9 +624,9 @@
     ioredis-mock "^5.6.0"
     iso8601-duration "^1.3.0"
     jsonwebtoken "^8.5.1"
-    medusa-core-utils "1.1.39-dev-1679077162720"
-    medusa-telemetry "0.0.16-dev-1679077162720"
-    medusa-test-utils "1.1.39-dev-1679077162720"
+    medusa-core-utils "1.2.0-snapshot-20230320172940"
+    medusa-telemetry "^0.0.16"
+    medusa-test-utils "1.1.40-snapshot-20230320172940"
     morgan "^1.9.1"
     multer "^1.4.4"
     node-schedule "^2.1.1"
@@ -655,15 +647,15 @@
     uuid "^8.3.2"
     winston "^3.8.2"
 
-"@medusajs/modules-sdk@0.0.1-dev-1679077162720":
-  version "0.0.1-dev-1679077162720"
-  resolved "http://localhost:4873/@medusajs%2fmodules-sdk/-/modules-sdk-0.0.1-dev-1679077162720.tgz#0d24c3c49fce1c7d94b338e370b0de1edd7a49dc"
-  integrity sha512-g6CE/oCvEePRxEkLXimOJNBIn1eLDu2IznuRddKC283DOpANT4WH9Xfw44ELZS+hkmcMzcatD7EYoxZ92HhesA==
+"@medusajs/modules-sdk@0.1.0-snapshot-20230320172940":
+  version "0.1.0-snapshot-20230320172940"
+  resolved "https://registry.yarnpkg.com/@medusajs/modules-sdk/-/modules-sdk-0.1.0-snapshot-20230320172940.tgz#d047afe015247e7886f42aa9df058392d82eea2b"
+  integrity sha512-sB1lqkWnHPO6twLuSNh/t9b5QkgeiQRMQMFbVH2z7d1EVsrXdcfB8xtmqw/kz4qonWYErFbH2PILgeNRMQsP7A==
   dependencies:
     awilix "^8.0.0"
     glob "7.1.6"
-    medusa-core-utils "1.1.39-dev-1679077162720"
-    medusa-telemetry "0.0.16-dev-1679077162720"
+    medusa-core-utils "1.2.0-snapshot-20230320172940"
+    medusa-telemetry "^0.0.16"
     resolve-cwd "^3.0.0"
 
 "@meilisearch/instant-meilisearch@^0.7.1":
@@ -923,6 +915,23 @@
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.2.0.tgz#8be36a1f66f3265389e90b5f9c9962146758f728"
   integrity sha512-sXo/qW2/pAcmT43VoRKOJbDOfV3cYpq3szSVfIThQXNt+E4DfKj361vaAt3c88U5tPUxzEswam7GW48PJqtKAg==
+
+"@sideway/address@^4.1.3":
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.4.tgz#03dccebc6ea47fdc226f7d3d1ad512955d4783f0"
+  integrity sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+
+"@sideway/formula@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@sideway/formula/-/formula-3.0.1.tgz#80fcbcbaf7ce031e0ef2dd29b1bfc7c3f583611f"
+  integrity sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==
+
+"@sideway/pinpoint@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@sideway/pinpoint/-/pinpoint-2.0.0.tgz#cff8ffadc372ad29fd3f78277aeb29e632cc70df"
+  integrity sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==
 
 "@stripe/react-stripe-js@^1.7.2":
   version "1.16.4"
@@ -1639,9 +1648,9 @@ axios-retry@^3.1.9:
     "@babel/runtime" "^7.15.4"
     is-retry-allowed "^2.2.0"
 
-axios@^0.21.4:
+axios@^0.21.1, axios@^0.21.4:
   version "0.21.4"
-  resolved "http://localhost:4873/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
   integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
   dependencies:
     follow-redirects "^1.14.0"
@@ -1652,15 +1661,6 @@ axios@^0.24.0:
   integrity sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==
   dependencies:
     follow-redirects "^1.14.4"
-
-axios@^1.2.0:
-  version "1.3.4"
-  resolved "http://localhost:4873/axios/-/axios-1.3.4.tgz#f5760cefd9cfb51fd2481acf88c05f67c4523024"
-  integrity sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==
-  dependencies:
-    follow-redirects "^1.15.0"
-    form-data "^4.0.0"
-    proxy-from-env "^1.1.0"
 
 axobject-query@^3.1.1:
   version "3.1.1"
@@ -2189,7 +2189,7 @@ colorspace@1.1.x:
     color "^3.1.3"
     text-hex "1.0.x"
 
-combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
+combined-stream@^1.0.6, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
@@ -3359,7 +3359,7 @@ fn.name@1.x.x:
   resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
   integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
 
-follow-redirects@^1.14.0, follow-redirects@^1.14.4, follow-redirects@^1.15.0:
+follow-redirects@^1.14.0, follow-redirects@^1.14.4:
   version "1.15.2"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
@@ -3375,15 +3375,6 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==
-
-form-data@^4.0.0:
-  version "4.0.0"
-  resolved "http://localhost:4873/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
-  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.8"
-    mime-types "^2.1.12"
 
 form-data@~2.3.2:
   version "2.3.3"
@@ -4316,6 +4307,22 @@ jest-worker@^27.4.5:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
+joi-objectid@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/joi-objectid/-/joi-objectid-3.0.1.tgz#63ace7860f8e1a993a28d40c40ffd8eff01a3668"
+  integrity sha512-V/3hbTlGpvJ03Me6DJbdBI08hBTasFOmipsauOsxOSnsF1blxV537WTl1zPwbfcKle4AK0Ma4OPnzMH4LlvTpQ==
+
+joi@^17.3.0:
+  version "17.9.0"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-17.9.0.tgz#52e161b6c91fc229799c3c948f0d219628423393"
+  integrity sha512-PWirKfKoZL3kWHfkGKzdCLGv23c00rI31PKVDMg33b/ANe+bMC/ZPdEnHAoHzn5Hy6BTg3J0A2yRVKzT64e6Xw==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+    "@hapi/topo" "^5.0.0"
+    "@sideway/address" "^4.1.3"
+    "@sideway/formula" "^3.0.1"
+    "@sideway/pinpoint" "^2.0.0"
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -4716,26 +4723,32 @@ media-typer@0.3.0:
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==
 
-medusa-core-utils@1.1.39-dev-1679077162720:
-  version "1.1.39-dev-1679077162720"
-  resolved "http://localhost:4873/medusa-core-utils/-/medusa-core-utils-1.1.39-dev-1679077162720.tgz#25507e0b5a9482a2ce03574f68b2391e12e8ad31"
-  integrity sha512-VjKYZAw2u+1IcGr8ALd5V/7l/W8lDVpHPeP/Nz1vQkslqZU3qaWhAePP7xr+olAGpiYMnocskMiH++MiO71y5g==
+medusa-core-utils@1.2.0-snapshot-20230320172940:
+  version "1.2.0-snapshot-20230320172940"
+  resolved "https://registry.yarnpkg.com/medusa-core-utils/-/medusa-core-utils-1.2.0-snapshot-20230320172940.tgz#8000c541f4cc07585a02d6301b78a41d3c294578"
+  integrity sha512-9YJONK5KCuEwnKdbWulOV4S9/5JEmeZj6L9sUNsPeLtv0W4YMPpmeGNgH5s0GNdCQIgxluqNhAxgG0GFhtUbFA==
 
-medusa-react@4.0.4-dev-1679077162720:
-  version "4.0.4-dev-1679077162720"
-  resolved "http://localhost:4873/medusa-react/-/medusa-react-4.0.4-dev-1679077162720.tgz#f28825305e1edcd8b0883bc493f5c8886c1d98e1"
-  integrity sha512-ASAIrIppWNOBTiS1VV7UwVqu39xGhl6zv8w1EvN+eD2cjza4qAPL5yKyrbIXz/XPY+3unlSI6g5N4kDHjJaX7w==
+medusa-core-utils@^1.1.39:
+  version "1.1.39"
+  resolved "https://registry.yarnpkg.com/medusa-core-utils/-/medusa-core-utils-1.1.39.tgz#72a4ed63a2779583dc8e5f2661763cfa13eed9d6"
+  integrity sha512-bceQdAuC//d41xn6JHOmBQudb/KD1qp0A9/tmMVdCkKuDguyHVNgIAoWRMymqXeCHMe+AS++38SEllYXWkLGag==
   dependencies:
-    "@medusajs/medusa-client-admin" "0.1.0-dev-1679077162720"
-    "@medusajs/medusa-client-store" "0.1.0-dev-1679077162720"
-    "@medusajs/medusa-js" "1.3.10-dev-1679077162720"
+    joi "^17.3.0"
+    joi-objectid "^3.0.1"
 
-medusa-telemetry@0.0.16-dev-1679077162720:
-  version "0.0.16-dev-1679077162720"
-  resolved "http://localhost:4873/medusa-telemetry/-/medusa-telemetry-0.0.16-dev-1679077162720.tgz#ae3f08842b07239ceca1283cd7bee4c79dfcc770"
-  integrity sha512-rQrEgYVv/BRpG9KGifN+5v0IQT2nUIcJgvwAc6q9iAeBuES12pjSrJvD6CHCl8sXhN3W7g10xBxUW3aJvoI8lg==
+medusa-react@5.0.0-snapshot-20230320172940:
+  version "5.0.0-snapshot-20230320172940"
+  resolved "https://registry.yarnpkg.com/medusa-react/-/medusa-react-5.0.0-snapshot-20230320172940.tgz#3bf5ebf3c49fb9becee1e66a281fdcb27e439439"
+  integrity sha512-dYxym0O+KY7WW9kiEGDqgxfL6zlLTimjAs81tVTDEWKMyYFCUMHQAZLFjkD3WtiKRFkZc1kNKELqHGJKaiEXMA==
   dependencies:
-    axios "^0.21.4"
+    "@medusajs/medusa-js" "2.0.0-snapshot-20230320172940"
+
+medusa-telemetry@0.0.16, medusa-telemetry@^0.0.16:
+  version "0.0.16"
+  resolved "https://registry.yarnpkg.com/medusa-telemetry/-/medusa-telemetry-0.0.16.tgz#f087494df4646c5c7cf281603595a213b50b116a"
+  integrity sha512-i9FVCfILzVQXXYuPCNf4h9BwTqi1uVyL08zzKLTCq/ttodyMb77TmnvolrE5XuvLsRbw3iqQ3aGq+sn0aURaVQ==
+  dependencies:
+    axios "^0.21.1"
     axios-retry "^3.1.9"
     boxen "^5.0.1"
     ci-info "^3.2.0"
@@ -4745,13 +4758,13 @@ medusa-telemetry@0.0.16-dev-1679077162720:
     remove-trailing-slash "^0.1.1"
     uuid "^8.3.2"
 
-medusa-test-utils@1.1.39-dev-1679077162720:
-  version "1.1.39-dev-1679077162720"
-  resolved "http://localhost:4873/medusa-test-utils/-/medusa-test-utils-1.1.39-dev-1679077162720.tgz#dd453e6df8c27aefec70312aa353afde13fa2e42"
-  integrity sha512-9Iipnec7uSeyBI4OJC4/Utz35AoioPCA2qP65GfN3KGf64JrSPqS32GIW5abFaF7Uu25/tglnEiucT1pyZJDwg==
+medusa-test-utils@1.1.40-snapshot-20230320172940:
+  version "1.1.40-snapshot-20230320172940"
+  resolved "https://registry.yarnpkg.com/medusa-test-utils/-/medusa-test-utils-1.1.40-snapshot-20230320172940.tgz#ac0b1fc585d6d0be47c39750a3fdef4521c6ef7f"
+  integrity sha512-QCvc+z4E19lN7VxGiMXo2qt877nnAlLjAjqFQk0bWXikpJsd4CLXhcQxgT+fKc8/DRsvx/y6FVVFgI69vBbV/w==
   dependencies:
     "@babel/plugin-transform-classes" "^7.9.5"
-    medusa-core-utils "1.1.39-dev-1679077162720"
+    medusa-core-utils "1.2.0-snapshot-20230320172940"
     randomatic "^3.1.1"
 
 meilisearch@0.25.1:
@@ -5779,11 +5792,6 @@ proxy-from-env@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.0.0.tgz#33c50398f70ea7eb96d21f7b817630a55791c7ee"
   integrity sha512-F2JHgJQ1iqwnHDcQjVBsq3n/uoaFL+iPW/eAeL7kVxy/2RrWaN4WroKjjvbsoRtv0ftelNyC01bjRhn/bhcf4A==
-
-proxy-from-env@^1.1.0:
-  version "1.1.0"
-  resolved "http://localhost:4873/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
-  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 psl@^1.1.28:
   version "1.9.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -446,18 +446,6 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
-"@hapi/hoek@^9.0.0":
-  version "9.3.0"
-  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.3.0.tgz#8368869dcb735be2e7f5cb7647de78e167a251fb"
-  integrity sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==
-
-"@hapi/topo@^5.0.0":
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/@hapi/topo/-/topo-5.1.0.tgz#dc448e332c6c6e37a4dc02fd84ba8d44b9afb012"
-  integrity sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==
-  dependencies:
-    "@hapi/hoek" "^9.0.0"
-
 "@headlessui/react@^1.6.1":
   version "1.7.7"
   resolved "https://registry.yarnpkg.com/@headlessui/react/-/react-1.7.7.tgz#d6f8708d8943ae8ebb1a6929108234e4515ac7e8"
@@ -547,14 +535,19 @@
     semver "^7.3.5"
     tar "^6.1.11"
 
-"@medusajs/medusa-cli@^1.3.6":
-  version "1.3.6"
-  resolved "https://registry.yarnpkg.com/@medusajs/medusa-cli/-/medusa-cli-1.3.6.tgz#7f88d91eb610b0ffd3cf60257c2e8376ee2956be"
-  integrity sha512-H2OOeLM4vxRSN/hMmREV2G4iVgRr3E9pQsWDuRdb3WQkViZSYOFL7eTdK3KedcLS10MyWLBkzv/dBnyLZv4X3w==
+"@medusajs/client-types@0.1.0-dev-1679077162720":
+  version "0.1.0-dev-1679077162720"
+  resolved "http://localhost:4873/@medusajs%2fclient-types/-/client-types-0.1.0-dev-1679077162720.tgz#49955f6aa72bda89512be9037c0f06008e46c3b8"
+  integrity sha512-FnPODgx0gOzMyFq+uIBNLXw3s7v9Hiwd6AJgDnALnXO7L6RXLXEbSWTb39LOgVdQXISsrze4yFgFNAkVpNwraw==
+
+"@medusajs/medusa-cli@1.3.8-dev-1679077162720":
+  version "1.3.8-dev-1679077162720"
+  resolved "http://localhost:4873/@medusajs%2fmedusa-cli/-/medusa-cli-1.3.8-dev-1679077162720.tgz#a7e11b706841319008d0e7d635b0f7d869ca085c"
+  integrity sha512-HBaDMhSS2K8bbj/olzDtu4FvEtCxO+yuuoUUtuR3ZnqTucrDVgKyJrQwc+lcdNs6P7dq8HKuHybUmmJ8VLwNdg==
   dependencies:
     "@babel/polyfill" "^7.8.7"
     "@babel/runtime" "^7.9.6"
-    axios "^0.21.1"
+    axios "^0.21.4"
     chalk "^4.0.0"
     configstore "5.0.1"
     core-js "^3.6.5"
@@ -565,79 +558,90 @@
     hosted-git-info "^4.0.2"
     inquirer "^8.0.0"
     is-valid-path "^0.1.1"
-    meant "^1.0.1"
-    medusa-core-utils "^1.1.31"
-    medusa-telemetry "0.0.16"
+    meant "^1.0.3"
+    medusa-core-utils "1.1.39-dev-1679077162720"
+    medusa-telemetry "0.0.16-dev-1679077162720"
     netrc-parser "^3.1.6"
     open "^8.0.6"
     ora "^5.4.1"
-    pg-god "^1.0.11"
-    prompts "^2.4.1"
-    regenerator-runtime "^0.13.5"
+    pg-god "^1.0.12"
+    prompts "^2.4.2"
+    regenerator-runtime "^0.13.11"
     resolve-cwd "^3.0.0"
     stack-trace "^0.0.10"
     ulid "^2.3.0"
     url "^0.11.0"
-    winston "^3.3.3"
+    winston "^3.8.2"
     yargs "^15.3.1"
 
-"@medusajs/medusa-js@^1.3.7":
-  version "1.3.7"
-  resolved "https://registry.yarnpkg.com/@medusajs/medusa-js/-/medusa-js-1.3.7.tgz#3cf2b9ebf5e8f92ab04f505d26c83d72548187e5"
-  integrity sha512-iwPzO6oY870092xCBEGrOhwfSLW8hGcGHitNbE/8iuJRfYVVfc2iTGEPmyjKAbyV9MF/U3J+OaM/in2yCrTHqQ==
+"@medusajs/medusa-client-admin@0.1.0-dev-1679077162720":
+  version "0.1.0-dev-1679077162720"
+  resolved "http://localhost:4873/@medusajs%2fmedusa-client-admin/-/medusa-client-admin-0.1.0-dev-1679077162720.tgz#bcb9cd3f030bcc46ea87100c939cdb5760bd9e8f"
+  integrity sha512-1CbM8xCS7bq9a7EJJrD4Cv/gRND1WF5JagTUhITN3e/OD6dP9e4DDDu3q/1qBfBXLtU2VIsJUM7QrSIRy/HxmQ==
+  dependencies:
+    "@medusajs/client-types" "0.1.0-dev-1679077162720"
+    axios "^1.2.0"
+    form-data "^4.0.0"
+    node-fetch "2.6.7"
+
+"@medusajs/medusa-client-store@0.1.0-dev-1679077162720":
+  version "0.1.0-dev-1679077162720"
+  resolved "http://localhost:4873/@medusajs%2fmedusa-client-store/-/medusa-client-store-0.1.0-dev-1679077162720.tgz#2c6eab2e5958b51e88396fee80ea1c1d0218cb84"
+  integrity sha512-azbX/tpqKmtWohNHxXDADGtX4Hs9FuehCwyL/yQURjC9ZbMc9RRK6ohpnFymN5wpePR+BEZEd9PKwEWWI0J94A==
+  dependencies:
+    "@medusajs/client-types" "0.1.0-dev-1679077162720"
+    axios "^1.2.0"
+    form-data "^4.0.0"
+    node-fetch "2.6.7"
+
+"@medusajs/medusa-js@1.3.10-dev-1679077162720":
+  version "1.3.10-dev-1679077162720"
+  resolved "http://localhost:4873/@medusajs%2fmedusa-js/-/medusa-js-1.3.10-dev-1679077162720.tgz#88d4cd1ace983a7efb1c4789dfd5db7576b6d7c0"
+  integrity sha512-eTLRug3dWnurbb27ChCnAHXPscUpZaZwUDllcaOXvvVirCBePjKwLX5ei6hsgytZqyNP3A+vc+Tszrn2jLSACA==
   dependencies:
     axios "^0.24.0"
     qs "^6.10.3"
     retry-axios "^2.6.0"
     uuid "^9.0.0"
 
-"@medusajs/medusa-js@^1.3.8":
-  version "1.3.8"
-  resolved "https://registry.yarnpkg.com/@medusajs/medusa-js/-/medusa-js-1.3.8.tgz#f94726386cb4f00adcc306cc4247dfb0bbd86232"
-  integrity sha512-yDiQDoaE45kSwRNScPff+icXK+YoJiYlSzcjazhuXiJWj1L6QG6uqevYY4hZQcjQejtNw2IzE86YSH0+V6xLAg==
+"@medusajs/medusa@1.7.13-dev-1679077162720":
+  version "1.7.13-dev-1679077162720"
+  resolved "http://localhost:4873/@medusajs%2fmedusa/-/medusa-1.7.13-dev-1679077162720.tgz#dcd19416fd37917c24be23fd3f2be246bfda8c23"
+  integrity sha512-f7vFCei8cqhyC1PHCYCuB5ATOO9Xxyx3fwKBKIDaTyQHCYKg06wLudhDMy0gghzNCxC8D/xEk5FlnLDPqUsLKg==
   dependencies:
-    axios "^0.24.0"
-    qs "^6.10.3"
-    retry-axios "^2.6.0"
-    uuid "^9.0.0"
-
-"@medusajs/medusa@^1.7.5":
-  version "1.7.5"
-  resolved "https://registry.yarnpkg.com/@medusajs/medusa/-/medusa-1.7.5.tgz#92b3229352db3737560472864ee50eb9c2ede858"
-  integrity sha512-zR4ZUpGYOPpTFRbUMZ92JEYSNTSKqC0KM3/fuwWtuPORlHHI6kM9fYpT7RWwF4hwy2xsk68DydB4XBqY55ViWQ==
-  dependencies:
-    "@medusajs/medusa-cli" "^1.3.6"
+    "@medusajs/medusa-cli" "1.3.8-dev-1679077162720"
+    "@medusajs/modules-sdk" "0.0.1-dev-1679077162720"
     "@types/ioredis" "^4.28.10"
-    "@types/lodash" "^4.14.168"
+    "@types/lodash" "^4.14.191"
     awilix "^8.0.0"
     body-parser "^1.19.0"
     bull "^3.12.1"
     chokidar "^3.4.2"
     class-transformer "^0.5.1"
-    class-validator "^0.13.1"
+    class-validator "^0.13.2"
     connect-redis "^5.0.0"
-    cookie-parser "^1.4.4"
+    cookie-parser "^1.4.6"
     core-js "^3.6.5"
     cors "^2.8.5"
     cross-spawn "^7.0.3"
     express "^4.17.1"
-    express-session "^1.17.1"
+    express-session "^1.17.3"
     fs-exists-cached "^1.0.0"
     glob "^7.1.6"
     ioredis "^4.17.3"
     ioredis-mock "^5.6.0"
     iso8601-duration "^1.3.0"
     jsonwebtoken "^8.5.1"
-    medusa-core-utils "^1.1.37"
-    medusa-telemetry "^0.0.16"
-    medusa-test-utils "^1.1.38"
+    medusa-core-utils "1.1.39-dev-1679077162720"
+    medusa-telemetry "0.0.16-dev-1679077162720"
+    medusa-test-utils "1.1.39-dev-1679077162720"
     morgan "^1.9.1"
-    multer "^1.4.2"
-    node-schedule "^2.1.0"
+    multer "^1.4.4"
+    node-schedule "^2.1.1"
     papaparse "^5.3.2"
-    passport "^0.4.0"
+    passport "^0.4.1"
     passport-http-bearer "^1.0.1"
-    passport-jwt "^4.0.0"
+    passport-jwt "^4.0.1"
     passport-local "^1.0.0"
     pg "^8.5.1"
     randomatic "^3.1.1"
@@ -648,8 +652,19 @@
     scrypt-kdf "^2.0.1"
     sqlite3 "^5.0.2"
     ulid "^2.3.0"
-    uuid "^8.3.1"
-    winston "^3.2.1"
+    uuid "^8.3.2"
+    winston "^3.8.2"
+
+"@medusajs/modules-sdk@0.0.1-dev-1679077162720":
+  version "0.0.1-dev-1679077162720"
+  resolved "http://localhost:4873/@medusajs%2fmodules-sdk/-/modules-sdk-0.0.1-dev-1679077162720.tgz#0d24c3c49fce1c7d94b338e370b0de1edd7a49dc"
+  integrity sha512-g6CE/oCvEePRxEkLXimOJNBIn1eLDu2IznuRddKC283DOpANT4WH9Xfw44ELZS+hkmcMzcatD7EYoxZ92HhesA==
+  dependencies:
+    awilix "^8.0.0"
+    glob "7.1.6"
+    medusa-core-utils "1.1.39-dev-1679077162720"
+    medusa-telemetry "0.0.16-dev-1679077162720"
+    resolve-cwd "^3.0.0"
 
 "@meilisearch/instant-meilisearch@^0.7.1":
   version "0.7.1"
@@ -909,23 +924,6 @@
   resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.2.0.tgz#8be36a1f66f3265389e90b5f9c9962146758f728"
   integrity sha512-sXo/qW2/pAcmT43VoRKOJbDOfV3cYpq3szSVfIThQXNt+E4DfKj361vaAt3c88U5tPUxzEswam7GW48PJqtKAg==
 
-"@sideway/address@^4.1.3":
-  version "4.1.4"
-  resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.4.tgz#03dccebc6ea47fdc226f7d3d1ad512955d4783f0"
-  integrity sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==
-  dependencies:
-    "@hapi/hoek" "^9.0.0"
-
-"@sideway/formula@^3.0.0":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@sideway/formula/-/formula-3.0.1.tgz#80fcbcbaf7ce031e0ef2dd29b1bfc7c3f583611f"
-  integrity sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==
-
-"@sideway/pinpoint@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@sideway/pinpoint/-/pinpoint-2.0.0.tgz#cff8ffadc372ad29fd3f78277aeb29e632cc70df"
-  integrity sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==
-
 "@stripe/react-stripe-js@^1.7.2":
   version "1.16.4"
   resolved "https://registry.yarnpkg.com/@stripe/react-stripe-js/-/react-stripe-js-1.16.4.tgz#d25c9bb93ae2d21d1d5a2d8a275e1e4e2732ba73"
@@ -1016,9 +1014,9 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
-"@types/lodash@^4.14.168":
+"@types/lodash@^4.14.191":
   version "4.14.191"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.191.tgz#09511e7f7cba275acd8b419ddac8da9a6a79e2fa"
+  resolved "http://localhost:4873/@types%2flodash/-/lodash-4.14.191.tgz#09511e7f7cba275acd8b419ddac8da9a6a79e2fa"
   integrity sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==
 
 "@types/node@*":
@@ -1641,9 +1639,9 @@ axios-retry@^3.1.9:
     "@babel/runtime" "^7.15.4"
     is-retry-allowed "^2.2.0"
 
-axios@^0.21.1:
+axios@^0.21.4:
   version "0.21.4"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
+  resolved "http://localhost:4873/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
   integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
   dependencies:
     follow-redirects "^1.14.0"
@@ -1654,6 +1652,15 @@ axios@^0.24.0:
   integrity sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==
   dependencies:
     follow-redirects "^1.14.4"
+
+axios@^1.2.0:
+  version "1.3.4"
+  resolved "http://localhost:4873/axios/-/axios-1.3.4.tgz#f5760cefd9cfb51fd2481acf88c05f67c4523024"
+  integrity sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==
+  dependencies:
+    follow-redirects "^1.15.0"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 axobject-query@^3.1.1:
   version "3.1.1"
@@ -1989,9 +1996,9 @@ class-transformer@^0.5.1:
   resolved "https://registry.yarnpkg.com/class-transformer/-/class-transformer-0.5.1.tgz#24147d5dffd2a6cea930a3250a677addf96ab336"
   integrity sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==
 
-class-validator@^0.13.1:
+class-validator@^0.13.2:
   version "0.13.2"
-  resolved "https://registry.yarnpkg.com/class-validator/-/class-validator-0.13.2.tgz#64b031e9f3f81a1e1dcd04a5d604734608b24143"
+  resolved "http://localhost:4873/class-validator/-/class-validator-0.13.2.tgz#64b031e9f3f81a1e1dcd04a5d604734608b24143"
   integrity sha512-yBUcQy07FPlGzUjoLuUfIOXzgynnQPPruyK1Ge2B74k9ROwnle1E+NxLWnUv5OLU8hA/qL5leAE9XnXq3byaBw==
   dependencies:
     libphonenumber-js "^1.9.43"
@@ -2182,7 +2189,7 @@ colorspace@1.1.x:
     color "^3.1.3"
     text-hex "1.0.x"
 
-combined-stream@^1.0.6, combined-stream@~1.0.6:
+combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
@@ -2263,9 +2270,9 @@ convert-source-map@^1.7.0:
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.9.0.tgz#7faae62353fb4213366d0ca98358d22e8368b05f"
   integrity sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==
 
-cookie-parser@^1.4.4:
+cookie-parser@^1.4.6:
   version "1.4.6"
-  resolved "https://registry.yarnpkg.com/cookie-parser/-/cookie-parser-1.4.6.tgz#3ac3a7d35a7a03bbc7e365073a26074824214594"
+  resolved "http://localhost:4873/cookie-parser/-/cookie-parser-1.4.6.tgz#3ac3a7d35a7a03bbc7e365073a26074824214594"
   integrity sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==
   dependencies:
     cookie "0.4.1"
@@ -3133,9 +3140,9 @@ expand-template@^2.0.3:
   resolved "https://registry.yarnpkg.com/expand-template/-/expand-template-2.0.3.tgz#6e14b3fcee0f3a6340ecb57d2e8918692052a47c"
   integrity sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==
 
-express-session@^1.17.1:
+express-session@^1.17.3:
   version "1.17.3"
-  resolved "https://registry.yarnpkg.com/express-session/-/express-session-1.17.3.tgz#14b997a15ed43e5949cb1d073725675dd2777f36"
+  resolved "http://localhost:4873/express-session/-/express-session-1.17.3.tgz#14b997a15ed43e5949cb1d073725675dd2777f36"
   integrity sha512-4+otWXlShYlG1Ma+2Jnn+xgKUZTMJ5QD3YvfilX3AcocOAbIkVylSWEklzALe/+Pu4qV6TYBj5GwOBFfdKqLBw==
   dependencies:
     cookie "0.4.2"
@@ -3352,7 +3359,7 @@ fn.name@1.x.x:
   resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
   integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
 
-follow-redirects@^1.14.0, follow-redirects@^1.14.4:
+follow-redirects@^1.14.0, follow-redirects@^1.14.4, follow-redirects@^1.15.0:
   version "1.15.2"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
@@ -3368,6 +3375,15 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "http://localhost:4873/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 form-data@~2.3.2:
   version "2.3.3"
@@ -3588,6 +3604,18 @@ glob-to-regexp@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
+
+glob@7.1.6:
+  version "7.1.6"
+  resolved "http://localhost:4873/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
+  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
 
 glob@7.1.7:
   version "7.1.7"
@@ -4288,22 +4316,6 @@ jest-worker@^27.4.5:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
-joi-objectid@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/joi-objectid/-/joi-objectid-3.0.1.tgz#63ace7860f8e1a993a28d40c40ffd8eff01a3668"
-  integrity sha512-V/3hbTlGpvJ03Me6DJbdBI08hBTasFOmipsauOsxOSnsF1blxV537WTl1zPwbfcKle4AK0Ma4OPnzMH4LlvTpQ==
-
-joi@^17.3.0:
-  version "17.7.0"
-  resolved "https://registry.yarnpkg.com/joi/-/joi-17.7.0.tgz#591a33b1fe1aca2bc27f290bcad9b9c1c570a6b3"
-  integrity sha512-1/ugc8djfn93rTE3WRKdCzGGt/EtiYKxITMO4Wiv6q5JL1gl9ePt4kBsl1S499nbosspfctIQTpYIhSmHA3WAg==
-  dependencies:
-    "@hapi/hoek" "^9.0.0"
-    "@hapi/topo" "^5.0.0"
-    "@sideway/address" "^4.1.3"
-    "@sideway/formula" "^3.0.0"
-    "@sideway/pinpoint" "^2.0.0"
-
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -4694,9 +4706,9 @@ math-random@^1.0.1:
   resolved "https://registry.yarnpkg.com/math-random/-/math-random-1.0.4.tgz#5dd6943c938548267016d4e34f057583080c514c"
   integrity sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==
 
-meant@^1.0.1:
+meant@^1.0.3:
   version "1.0.3"
-  resolved "https://registry.yarnpkg.com/meant/-/meant-1.0.3.tgz#67769af9de1d158773e928ae82c456114903554c"
+  resolved "http://localhost:4873/meant/-/meant-1.0.3.tgz#67769af9de1d158773e928ae82c456114903554c"
   integrity sha512-88ZRGcNxAq4EH38cQ4D85PM57pikCwS8Z99EWHODxN7KBY+UuPiqzRTtZzS8KTXO/ywSWbdjjJST2Hly/EQxLw==
 
 media-typer@0.3.0:
@@ -4704,27 +4716,26 @@ media-typer@0.3.0:
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==
 
-medusa-core-utils@^1.1.31, medusa-core-utils@^1.1.32, medusa-core-utils@^1.1.37:
-  version "1.1.37"
-  resolved "https://registry.yarnpkg.com/medusa-core-utils/-/medusa-core-utils-1.1.37.tgz#52bee710fc10674d4a9bd71874aea7385eb482e8"
-  integrity sha512-FhtVqalSHRndKVe/wDvJUVMtarP26Y7/XEa6RGVDZoc+lpJDHYXqF+Cpqepne7yKKALIhLo+q67Csei6HF/c0A==
-  dependencies:
-    joi "^17.3.0"
-    joi-objectid "^3.0.1"
+medusa-core-utils@1.1.39-dev-1679077162720:
+  version "1.1.39-dev-1679077162720"
+  resolved "http://localhost:4873/medusa-core-utils/-/medusa-core-utils-1.1.39-dev-1679077162720.tgz#25507e0b5a9482a2ce03574f68b2391e12e8ad31"
+  integrity sha512-VjKYZAw2u+1IcGr8ALd5V/7l/W8lDVpHPeP/Nz1vQkslqZU3qaWhAePP7xr+olAGpiYMnocskMiH++MiO71y5g==
 
-medusa-react@^4.0.4:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/medusa-react/-/medusa-react-4.0.4.tgz#84f96dc1e613b1979e7534758b6c72fd26c87317"
-  integrity sha512-0epeLgDZ+A2jtd9SCzaXrLhUSbzRr0osgmdABFBD4zPCr0qSAH+WaWCXAdEEQbb5SlwgvnVpJ+Ly4Iw1xj73mg==
+medusa-react@4.0.4-dev-1679077162720:
+  version "4.0.4-dev-1679077162720"
+  resolved "http://localhost:4873/medusa-react/-/medusa-react-4.0.4-dev-1679077162720.tgz#f28825305e1edcd8b0883bc493f5c8886c1d98e1"
+  integrity sha512-ASAIrIppWNOBTiS1VV7UwVqu39xGhl6zv8w1EvN+eD2cjza4qAPL5yKyrbIXz/XPY+3unlSI6g5N4kDHjJaX7w==
   dependencies:
-    "@medusajs/medusa-js" "^1.3.8"
+    "@medusajs/medusa-client-admin" "0.1.0-dev-1679077162720"
+    "@medusajs/medusa-client-store" "0.1.0-dev-1679077162720"
+    "@medusajs/medusa-js" "1.3.10-dev-1679077162720"
 
-medusa-telemetry@0.0.16, medusa-telemetry@^0.0.16:
-  version "0.0.16"
-  resolved "https://registry.yarnpkg.com/medusa-telemetry/-/medusa-telemetry-0.0.16.tgz#f087494df4646c5c7cf281603595a213b50b116a"
-  integrity sha512-i9FVCfILzVQXXYuPCNf4h9BwTqi1uVyL08zzKLTCq/ttodyMb77TmnvolrE5XuvLsRbw3iqQ3aGq+sn0aURaVQ==
+medusa-telemetry@0.0.16-dev-1679077162720:
+  version "0.0.16-dev-1679077162720"
+  resolved "http://localhost:4873/medusa-telemetry/-/medusa-telemetry-0.0.16-dev-1679077162720.tgz#ae3f08842b07239ceca1283cd7bee4c79dfcc770"
+  integrity sha512-rQrEgYVv/BRpG9KGifN+5v0IQT2nUIcJgvwAc6q9iAeBuES12pjSrJvD6CHCl8sXhN3W7g10xBxUW3aJvoI8lg==
   dependencies:
-    axios "^0.21.1"
+    axios "^0.21.4"
     axios-retry "^3.1.9"
     boxen "^5.0.1"
     ci-info "^3.2.0"
@@ -4734,13 +4745,13 @@ medusa-telemetry@0.0.16, medusa-telemetry@^0.0.16:
     remove-trailing-slash "^0.1.1"
     uuid "^8.3.2"
 
-medusa-test-utils@^1.1.38:
-  version "1.1.38"
-  resolved "https://registry.yarnpkg.com/medusa-test-utils/-/medusa-test-utils-1.1.38.tgz#62e89bb94545124a5e3e4298265d7cd94ce24bff"
-  integrity sha512-nDbfPrTnnsjxAZ03Er252i4ztR0P0n9CmwznzQSgO+qMwNBujavTEQs5r6zN0uS6/xmnvGBJwp4AneeiPuLPGg==
+medusa-test-utils@1.1.39-dev-1679077162720:
+  version "1.1.39-dev-1679077162720"
+  resolved "http://localhost:4873/medusa-test-utils/-/medusa-test-utils-1.1.39-dev-1679077162720.tgz#dd453e6df8c27aefec70312aa353afde13fa2e42"
+  integrity sha512-9Iipnec7uSeyBI4OJC4/Utz35AoioPCA2qP65GfN3KGf64JrSPqS32GIW5abFaF7Uu25/tglnEiucT1pyZJDwg==
   dependencies:
     "@babel/plugin-transform-classes" "^7.9.5"
-    medusa-core-utils "^1.1.32"
+    medusa-core-utils "1.1.39-dev-1679077162720"
     randomatic "^3.1.1"
 
 meilisearch@0.25.1:
@@ -4945,9 +4956,9 @@ ms@2.1.3, ms@^2.0.0, ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-multer@^1.4.2:
+multer@^1.4.4:
   version "1.4.4"
-  resolved "https://registry.yarnpkg.com/multer/-/multer-1.4.4.tgz#e2bc6cac0df57a8832b858d7418ccaa8ebaf7d8c"
+  resolved "http://localhost:4873/multer/-/multer-1.4.4.tgz#e2bc6cac0df57a8832b858d7418ccaa8ebaf7d8c"
   integrity sha512-2wY2+xD4udX612aMqMcB8Ws2Voq6NIUPEtD1be6m411T4uDH/VtL9i//xvcyFlTVfRdaBsk7hV5tgrGQqhuBiw==
   dependencies:
     append-field "^1.0.0"
@@ -5093,9 +5104,9 @@ node-releases@^2.0.6:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.8.tgz#0f349cdc8fcfa39a92ac0be9bc48b7706292b9ae"
   integrity sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A==
 
-node-schedule@^2.1.0:
+node-schedule@^2.1.1:
   version "2.1.1"
-  resolved "https://registry.yarnpkg.com/node-schedule/-/node-schedule-2.1.1.tgz#6958b2c5af8834954f69bb0a7a97c62b97185de3"
+  resolved "http://localhost:4873/node-schedule/-/node-schedule-2.1.1.tgz#6958b2c5af8834954f69bb0a7a97c62b97185de3"
   integrity sha512-OXdegQq03OmXEjt2hZP33W2YPs/E5BcFQks46+G2gAxs4gHOIVD1u7EqlYLYSKsaIpyKCK9Gbk0ta1/gjRSMRQ==
   dependencies:
     cron-parser "^4.2.0"
@@ -5414,9 +5425,9 @@ passport-http-bearer@^1.0.1:
   dependencies:
     passport-strategy "1.x.x"
 
-passport-jwt@^4.0.0:
+passport-jwt@^4.0.1:
   version "4.0.1"
-  resolved "https://registry.yarnpkg.com/passport-jwt/-/passport-jwt-4.0.1.tgz#c443795eff322c38d173faa0a3c481479646ec3d"
+  resolved "http://localhost:4873/passport-jwt/-/passport-jwt-4.0.1.tgz#c443795eff322c38d173faa0a3c481479646ec3d"
   integrity sha512-UCKMDYhNuGOBE9/9Ycuoyh7vP6jpeTp/+sfMJl7nLff/t6dps+iaeE0hhNkKN8/HZHcJ7lCdOyDxHdDoxoSvdQ==
   dependencies:
     jsonwebtoken "^9.0.0"
@@ -5434,9 +5445,9 @@ passport-strategy@1.x.x, passport-strategy@^1.0.0:
   resolved "https://registry.yarnpkg.com/passport-strategy/-/passport-strategy-1.0.0.tgz#b5539aa8fc225a3d1ad179476ddf236b440f52e4"
   integrity sha512-CB97UUvDKJde2V0KDWWB3lyf6PC3FaZP7YxZ2G8OAtn9p4HI9j9JLP9qjOGZFvyl8uwNT8qM+hGnz/n16NI7oA==
 
-passport@^0.4.0:
+passport@^0.4.1:
   version "0.4.1"
-  resolved "https://registry.yarnpkg.com/passport/-/passport-0.4.1.tgz#941446a21cb92fc688d97a0861c38ce9f738f270"
+  resolved "http://localhost:4873/passport/-/passport-0.4.1.tgz#941446a21cb92fc688d97a0861c38ce9f738f270"
   integrity sha512-IxXgZZs8d7uFSt3eqNjM9NQ3g3uQCW5avD8mRNoXV99Yig50vjuaez6dQK2qC0kVWPRTujxY0dWgGfT09adjYg==
   dependencies:
     passport-strategy "1.x.x"
@@ -5505,9 +5516,9 @@ pg-connection-string@^2.5.0:
   resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-2.5.0.tgz#538cadd0f7e603fc09a12590f3b8a452c2c0cf34"
   integrity sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ==
 
-pg-god@^1.0.11:
+pg-god@^1.0.12:
   version "1.0.12"
-  resolved "https://registry.yarnpkg.com/pg-god/-/pg-god-1.0.12.tgz#beaabef33eb4f359718dc64b1524be8370766801"
+  resolved "http://localhost:4873/pg-god/-/pg-god-1.0.12.tgz#beaabef33eb4f359718dc64b1524be8370766801"
   integrity sha512-6bxfBlyu0w9NN5hwHg5TksPNJZm729cGIsff0m1BiwX4NUsHY7FoTWVAfgMaSy4QPL4rVR7ShyUv/AZ4Yd2Rug==
   dependencies:
     "@oclif/command" "^1"
@@ -5739,9 +5750,9 @@ promise.prototype.finally@^3.1.2:
     define-properties "^1.1.4"
     es-abstract "^1.20.4"
 
-prompts@^2.4.1:
+prompts@^2.4.2:
   version "2.4.2"
-  resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.4.2.tgz#7b57e73b3a48029ad10ebd44f74b01722a4cb069"
+  resolved "http://localhost:4873/prompts/-/prompts-2.4.2.tgz#7b57e73b3a48029ad10ebd44f74b01722a4cb069"
   integrity sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==
   dependencies:
     kleur "^3.0.3"
@@ -5768,6 +5779,11 @@ proxy-from-env@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.0.0.tgz#33c50398f70ea7eb96d21f7b817630a55791c7ee"
   integrity sha512-F2JHgJQ1iqwnHDcQjVBsq3n/uoaFL+iPW/eAeL7kVxy/2RrWaN4WroKjjvbsoRtv0ftelNyC01bjRhn/bhcf4A==
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "http://localhost:4873/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 psl@^1.1.28:
   version "1.9.0"
@@ -6018,7 +6034,7 @@ reflect-metadata@^0.1.13:
   resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.13.tgz#67ae3ca57c972a2aa1642b10fe363fe32d49dc08"
   integrity sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==
 
-regenerator-runtime@^0.13.11, regenerator-runtime@^0.13.4, regenerator-runtime@^0.13.5:
+regenerator-runtime@^0.13.11, regenerator-runtime@^0.13.4:
   version "0.13.11"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
   integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
@@ -6994,7 +7010,7 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
-uuid@^8.3.0, uuid@^8.3.1, uuid@^8.3.2:
+uuid@^8.3.0, uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
@@ -7166,9 +7182,9 @@ winston-transport@^4.5.0:
     readable-stream "^3.6.0"
     triple-beam "^1.3.0"
 
-winston@^3.2.1, winston@^3.3.3:
+winston@^3.8.2:
   version "3.8.2"
-  resolved "https://registry.yarnpkg.com/winston/-/winston-3.8.2.tgz#56e16b34022eb4cff2638196d9646d7430fdad50"
+  resolved "http://localhost:4873/winston/-/winston-3.8.2.tgz#56e16b34022eb4cff2638196d9646d7430fdad50"
   integrity sha512-MsE1gRx1m5jdTTO9Ld/vND4krP2To+lgDoMEHGGa4HIlAUyXJtfc7CxQcGXVyz2IBpw5hbFkj2b/AtUdQwyRew==
   dependencies:
     "@colors/colors" "1.5.0"


### PR DESCRIPTION
## What

Import types from `@medusajs/client-types` package instead of importing from `@medusajs/medusa` core package.

## Why

Importing from the core package can lead to side effects where other backend dependencies are imported in client code.

## How

The `@medusajs/client-types` defines model relations as optional. This differs from the core package. This breaking change need to be handled. 

Note that if an endpoint is known to automatically populate some of its model relations, the types representing its response will alter the shape of their model in order to declare specific relations as not-optional and not-null.

* Replace all imports from `@medusajs/medusa` by `@medusajs/client-types`
* Redeclare Props types that are expecting relations to be present by using `@medusajs/client-types` `SetRelation` type mutator.
* Use a version of `@medusajs/medusa-js` that has been updated to use `@medusajs/client-types`
* Use a version of `medusa-react` that has been updated to use `@medusajs/client-types`