### PR TITLE
disable add to cart when no variant

### DIFF
--- a/src/modules/products/components/product-actions/index.tsx
+++ b/src/modules/products/components/product-actions/index.tsx
@@ -83,7 +83,7 @@ const ProductActions: React.FC<ProductActionsProps> = ({ product }) => {
         )}
       </div>
 
-      <Button onClick={addToCart}>
+      <Button onClick={addToCart} disabled={!variant}>
         {!inStock ? "Out of stock" : "Add to cart"}
       </Button>
     </div>


### PR DESCRIPTION
The add to cart button doesn't do anything when there is no variant selected which makes sense because you need to pick a size when buying a sweatshirt. However the button looks like it's an active button and looks like it's being clicked. This change makes the UI reflect the underlying reality of the button not doing anything.

Note that I'm brand new to Medusa and e-commerce in general, I won't be offended if I'm told I'm off base. For example, perhaps there are products that don't have variants, what happens then? Given that the seed data has variants this provides for a better first time experience but perhaps isn't fully correct.