### PR TITLE
fix: move link into popover button

### DIFF
--- a/src/modules/layout/components/cart-dropdown/index.tsx
+++ b/src/modules/layout/components/cart-dropdown/index.tsx
@@ -20,9 +20,9 @@ const CartDropdown = () => {
   return (
     <div className="h-full z-50" onMouseEnter={open} onMouseLeave={close}>
       <Popover className="relative h-full">
-        <Link href="/cart" passHref>
-          <Popover.Button className="h-full">{`My Bag (${totalItems})`}</Popover.Button>
-        </Link>
+        <Popover.Button className="h-full">
+          <Link href="/cart">{`My Bag (${totalItems})`}</Link>
+        </Popover.Button>
         <Transition
           show={state}
           as={Fragment}


### PR DESCRIPTION
The cart button was not clickable in the demo. For some reason the Popover.Button component doesn't work well with the Next Link. I've moved the link component into the button and it seems to fix the issue.