### PR TITLE
Change objectFit from cover to contain for product images and thumbnails

### DIFF
--- a/src/modules/products/components/image-gallary/index.tsx
+++ b/src/modules/products/components/image-gallary/index.tsx
@@ -40,7 +40,7 @@ const ImageGallery = ({ images }: ImageGalleryProps) => {
                 fill
                 sizes="100vw"
                 style={{
-                  objectFit: "cover",
+                  objectFit: "contain",
                 }}
               />
             </button>
@@ -64,7 +64,7 @@ const ImageGallery = ({ images }: ImageGalleryProps) => {
                 fill
                 sizes="100vw"
                 style={{
-                  objectFit: "cover",
+                  objectFit: "contain",
                 }}
               />
             </div>

--- a/src/modules/products/components/thumbnail/index.tsx
+++ b/src/modules/products/components/thumbnail/index.tsx
@@ -44,7 +44,7 @@ const ImageOrPlaceholder = ({
       fill
       sizes="100vw"
       style={{
-        objectFit: "cover",
+        objectFit: "contain",
         objectPosition: "center",
       }}
     />


### PR DESCRIPTION
I used the nextjs starter and when I uploaded images that were not 1:1 aspect ratio, the preview and thumbnail looked bad because the middle part of the picture was zoomed in to fill in the image container. objectFit: "contain" fixes this issue by preserving the aspect ratio of the image if it is not sized as 1:1. Here is an example of how the result can look: https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit