### PR TITLE
Fixing missing error messages & missing red borders on invalid inputs

### DIFF
--- a/src/modules/checkout/components/shipping-address/index.tsx
+++ b/src/modules/checkout/components/shipping-address/index.tsx
@@ -25,7 +25,10 @@ const ShippingAddress = () => {
               label="Email"
               {...register("email", {
                 required: "Email is required",
-                pattern: emailRegex,
+                pattern: {
+                  value: emailRegex,
+                  message: "Email address is invalid"
+                },
               })}
               autoComplete="email"
               errors={errors}

--- a/src/modules/common/components/input/index.tsx
+++ b/src/modules/common/components/input/index.tsx
@@ -3,7 +3,7 @@ import Eye from "@modules/common/icons/eye"
 import EyeOff from "@modules/common/icons/eye-off"
 import clsx from "clsx"
 import React, { useEffect, useImperativeHandle, useState } from "react"
-import { get } from "react-hook-form"
+import { get } from "lodash"
 
 type InputProps = Omit<
   React.InputHTMLAttributes<HTMLInputElement>,
@@ -33,8 +33,6 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
 
     useImperativeHandle(ref, () => inputRef.current!)
 
-    const hasError = get(errors, name) && get(touched, name)
-
     return (
       <div>
         <div className="relative z-0 w-full text-base-regular">
@@ -45,7 +43,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
             className={clsx(
               "pt-4 pb-1 block w-full px-4 mt-0 bg-transparent border appearance-none focus:outline-none focus:ring-0 focus:border-gray-400 border-gray-200",
               {
-                "border-rose-500 focus:border-rose-500": hasError,
+                "border-rose-500 focus:border-rose-500": errors ? get(errors, name) : false,
               }
             )}
             {...props}
@@ -57,7 +55,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
             className={clsx(
               "mx-3 px-1 transition-all absolute duration-300 top-3 -z-1 origin-0 text-gray-500",
               {
-                "!text-rose-500": hasError,
+                "!text-rose-500": errors ? get(errors, name) : false,
               }
             )}
           >
@@ -74,7 +72,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
             </button>
           )}
         </div>
-        {hasError && (
+        {(
           <ErrorMessage
             errors={errors}
             name={name}


### PR DESCRIPTION
Hi Medusa team. Thanks for the hard work on all you've been doing. I've been building with it for a few months and it's been great.

There are a couple of quick, simple fixes in this PR. First, I noticed that red error messages weren't appearing underneath invalid inputs. Then, secondly, as I was fixing the first issue, I noticed that red borders around input boxes were not appearing when users made invalid inputs. Error messages and red borders for invalid inputs were not features that I added myself, or had the idea of adding—they were features that were already present in the storefront starter, but were broken in some way, and needed fixing.

Here's a series of videos demonstrating the error and showing off the solution.

https://github.com/medusajs/nextjs-starter-medusa/assets/20936991/6507225e-ed17-4cbf-9df5-bda067b43e94
https://github.com/medusajs/nextjs-starter-medusa/assets/20936991/858f74a9-b5e1-4e69-8229-8f40fd741ded

The first commit is really simple. The email input field on the checkout page in the shipping address section never showed an error message for improperly formatted email addresses, so I took a look at it. The react-hook-form pattern property was missing a message to show to the user, so I changed it to an object containing the value of the pattern to check against (the emailRegex) and an appropriate message ("Email address is invalid").

The second commit is on the <Input /> component. It turns out that get() from react-hook-form did nothing (returned undefined all the time), so I got rid of it. This is why hasError and the boolean comparisons with hasError never worked. Instead, I used Lodash's get() method to check for the name of the input on the errors object. If the name is present on the errors object, there is an error with the input field, and the whole condition returns true, turning the border red. Otherwise, it's false, and the border won't be red. Also, the <ErrorMessage /> component will appear and disappear on its own depending on whether or not there's an error with the input, so there is no need to try and control whether or not it renders with &&.

I've tested this stuff out and it works with the input fields on shipping address, billing address, login, and register. I think that's all of them. 

I didn't see any contribution rules on this repo so I just tried to make everything simple and clear and do my best to follow common-sense contribution guidelines. This is also my first time contributing code to an open-source repo. Hopefully everything is up to snuff.