### PR TITLE
fixed issue of only the first ordered item's thumbnail being shown in …

### DIFF
--- a/src/modules/account/components/order-card/index.tsx
+++ b/src/modules/account/components/order-card/index.tsx
@@ -43,7 +43,7 @@ const OrderCard = ({ order }: OrderCardProps) => {
           return (
             <div key={i.id} className="flex flex-col gap-y-2">
               <Thumbnail
-                thumbnail={order.items[0].thumbnail}
+                thumbnail={i.thumbnail}
                 images={[]}
                 size="full"
               />


### PR DESCRIPTION
Noticed that thumbnail of only the first item was being displayed when checking the orders section inside account page. The issue was caused because of hard coding the value.