### PR TITLE
fix NextRouter was not mounted error in Search

### DIFF
--- a/src/modules/search/components/desktop-hit/index.tsx
+++ b/src/modules/search/components/desktop-hit/index.tsx
@@ -1,6 +1,6 @@
 import { useModal } from "@lib/context/modal-context"
 import Hit, { HitProps } from "@modules/search/components/hit"
-import { useRouter } from "next/router"
+import { useRouter } from "next/navigation"
 
 const DesktopHit = ({ hit }: HitProps) => {
   const { close } = useModal()

--- a/src/modules/search/components/mobile-hit/index.tsx
+++ b/src/modules/search/components/mobile-hit/index.tsx
@@ -1,6 +1,6 @@
 import { useMobileMenu } from "@lib/context/mobile-menu-context"
 import Hit, { HitProps } from "@modules/search/components/hit"
-import { useRouter } from "next/router"
+import { useRouter } from "next/navigation"
 
 const MobileHit = ({ hit }: HitProps) => {
   const { close } = useMobileMenu()


### PR DESCRIPTION
When enabling search, the error `NextRouter` was not mounted occurs.
More info: https://nextjs.org/docs/messages/next-router-not-mounted