### PR TITLE
fix: remove store button outline in main nav

### DIFF
--- a/src/modules/layout/components/dropdown-menu/index.tsx
+++ b/src/modules/layout/components/dropdown-menu/index.tsx
@@ -32,7 +32,7 @@ const DropdownMenu = () => {
             <Link href="/store" className="relative flex h-full" passHref>
               <Popover.Button
                 className={clsx(
-                  "relative h-full flex items-center transition-all ease-out duration-200"
+                  "relative h-full flex items-center transition-all ease-out duration-200 focus:outline-none"
                 )}
                 onClick={() => push("/store")}
               >


### PR DESCRIPTION
Removes outline around Store button in the main nav component. The outline pops up when you click the store button.