### PR TITLE
fix: fix incorrect variable name in .env.template

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -17,7 +17,7 @@ NEXT_PUBLIC_PAYPAL_CLIENT_ID=
 NEXT_PUBLIC_SEARCH_APP_ID=
 NEXT_PUBLIC_SEARCH_ENDPOINT=http://127.0.0.1:7700
 NEXT_PUBLIC_SEARCH_API_KEY=
-NEXT_PUBLIC_SEARCH_INDEX_NAME=products
+NEXT_PUBLIC_INDEX_NAME=products
 
 # Your Next.js revalidation secret. See – https://nextjs.org/docs/app/building-your-application/data-fetching/fetching-caching-and-revalidating#on-demand-revalidation
 REVALIDATE_SECRET=supersecret


### PR DESCRIPTION
Based on [search-client.ts](https://github.com/medusajs/nextjs-starter-medusa/blob/main/src/lib/search-client.ts), the environment variable name for the search index should be `NEXT_PUBLIC_INDEX_NAME` instead of `NEXT_PUBLIC_SEARCH_INDEX_NAME`