### PR TITLE
fix: Subtotal in cart is excl. taxes

### DIFF
--- a/src/modules/layout/components/cart-dropdown/index.tsx
+++ b/src/modules/layout/components/cart-dropdown/index.tsx
@@ -98,7 +98,7 @@ const CartDropdown = () => {
                   <div className="flex items-center justify-between">
                     <span className="text-gray-700 font-semibold">
                       Subtotal{" "}
-                      <span className="font-normal">(incl. taxes)</span>
+                      <span className="font-normal">(excl. taxes)</span>
                     </span>
                     <span className="text-large-semi">
                       {formatAmount({


### PR DESCRIPTION
See: https://github.com/medusajs/nextjs-starter-medusa/blob/9f0274ab56feb971c89ff71d3dfbe2da6e5939e0/src/modules/layout/components/cart-dropdown/index.tsx#L107