### PR TITLE
fix: fallback when stripe key is empty

### DIFF
--- a/src/modules/checkout/components/payment-wrapper/index.tsx
+++ b/src/modules/checkout/components/payment-wrapper/index.tsx
@@ -25,7 +25,8 @@ const Wrapper: React.FC<WrapperProps> = ({ paymentSession, children }) => {
   }
 }
 
-const stripePromise = loadStripe(process.env.NEXT_PUBLIC_STRIPE_KEY || "")
+const stripeKey = process.env.NEXT_PUBLIC_STRIPE_KEY
+const stripePromise = stripeKey ? loadStripe(stripeKey) : null
 
 const StripeWrapper: React.FC<WrapperProps> = ({
   paymentSession,
@@ -33,6 +34,10 @@ const StripeWrapper: React.FC<WrapperProps> = ({
 }) => {
   const options: StripeElementsOptions = {
     clientSecret: paymentSession!.data.client_secret as string | undefined,
+  }
+
+  if (!stripePromise) {
+    return <div>{children}</div>
   }
 
   return (


### PR DESCRIPTION
Prevents `loadStripe()` from being called with an empty Stripe key. This was causing errors in Firefox.