### PR TITLE
fix: center the search page position

### DIFF
--- a/src/modules/common/components/modal/index.tsx
+++ b/src/modules/common/components/modal/index.tsx
@@ -97,7 +97,7 @@ const Description: React.FC = ({ children }) => {
 }
 
 const Body: React.FC = ({ children }) => {
-  return <div className="flex-1">{children}</div>
+  return <div className="flex justify-center">{children}</div>
 }
 
 const Footer: React.FC = ({ children }) => {


### PR DESCRIPTION
![204158@2x](https://github.com/medusajs/nextjs-starter-medusa/assets/134155599/4ac0ac33-890b-4af8-9d22-0f242c683441)
