### PR TITLE
fix: adjust the padding on the mobile account page

### DIFF
--- a/src/modules/account/templates/account-layout.tsx
+++ b/src/modules/account/templates/account-layout.tsx
@@ -24,7 +24,7 @@ const AccountLayout: React.FC = ({ children }) => {
   return (
     <div className="flex-1 small:py-12">
       <div className="flex-1 h-full max-w-5xl mx-auto bg-white flex flex-col">
-        <div className="grid grid-cols-1 small:grid-cols-[240px_1fr] small:px-8 py-6 small:py-12 ">
+        <div className="grid grid-cols-1 small:grid-cols-[240px_1fr] px-8 py-12">
           <div>
             <AccountNav />
           </div>


### PR DESCRIPTION
Before:
<img width="389" alt="image" src="https://github.com/medusajs/nextjs-starter-medusa/assets/134155599/676f33a2-7812-45e1-b319-c2ffa5a40c96">
After:
<img width="391" alt="image" src="https://github.com/medusajs/nextjs-starter-medusa/assets/134155599/7bde515e-9f5d-421f-9adb-d71aecc3ad52">
