### PR TITLE
checkout stripe error

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,9 +8,9 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" data-mode="light">
-      <body className="h-screen">
+      <body>
         <Providers>
-          <main className="relative h-screen">{children}</main>
+          <main className="relative">{children}</main>
         </Providers>
       </body>
     </html>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,9 +8,9 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" data-mode="light">
-      <body>
+      <body className="h-screen">
         <Providers>
-          <main className="relative">{children}</main>
+          <main className="relative h-screen">{children}</main>
         </Providers>
       </body>
     </html>

--- a/src/lib/context/checkout-context.tsx
+++ b/src/lib/context/checkout-context.tsx
@@ -29,6 +29,7 @@ import React, {
 } from "react"
 import { FormProvider, useForm, useFormContext } from "react-hook-form"
 import { useStore } from "./store-context"
+import Spinner from "@modules/common/icons/spinner"
 
 type AddressValues = {
   first_name: string
@@ -137,6 +138,12 @@ export const CheckoutProvider = ({ children }: CheckoutProviderProps) => {
   const isLoading = useMemo(() => {
     return addingShippingMethod || settingPaymentSession || updatingCart
   }, [addingShippingMethod, settingPaymentSession, updatingCart])
+
+  useMemo(() => {
+    if (cart?.payment_session?.provider_id) {
+      setSelectedPaymentOptionId(cart.payment_session.provider_id)
+    }
+  }, [cart?.payment_session?.provider_id])
 
   /**
    * Boolean that indicates if the checkout is ready to be completed. A checkout is ready to be completed if
@@ -361,12 +368,20 @@ export const CheckoutProvider = ({ children }: CheckoutProviderProps) => {
           onPaymentCompleted,
         }}
       >
-        <Wrapper
-          selectedProviderId={selectedPaymentOptionId}
-          paymentSession={cart?.payment_session}
-        >
-          {children}
-        </Wrapper>
+        {isLoading && cart?.id === "" ? (
+          <div className="flex justify-center items-center h-screen">
+            <div className="w-auto">
+              <Spinner size={40} />
+            </div>
+          </div>
+        ) : (
+          <Wrapper
+            selectedProviderId={selectedPaymentOptionId}
+            paymentSession={cart?.payment_session}
+          >
+            {children}
+          </Wrapper>
+        )}
       </CheckoutContext.Provider>
     </FormProvider>
   )


### PR DESCRIPTION
fixes this

```
Unhandled Runtime Error
Error: Could not find Elements context; You need to wrap the part of your app that calls useStripe() in an <Elements> provider.

Source
src/modules/checkout/components/payment-button/index.tsx (76:26) @ useStripe

  74 | const { onPaymentCompleted } = useCheckout()
  75 |
> 76 | const stripe = useStripe()
     |                        ^
  77 | const elements = useElements()
  78 | const card = elements?.getElement("cardNumber")
  79 |
```
