### PR TITLE
fix: meilisearch support

### DIFF
--- a/src/app/(main)/search/[query]/page.tsx
+++ b/src/app/(main)/search/[query]/page.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
 export default async function StorePage({
   params,
 }: {
-  params: Record<string, any>
+  params: { query: string }
 }) {
   const { query } = params
   const hits = await search(query)

--- a/src/app/(main)/search/actions.ts
+++ b/src/app/(main)/search/actions.ts
@@ -3,11 +3,22 @@
 import { searchClient, SEARCH_INDEX_NAME } from "@lib/search-client"
 
 /**
- * Uses Algolia to search for a query
+ * Uses MeiliSearch or Algolia to search for a query
  * @param {string} query - search query
  */
 export async function search(query: string) {
-  const index = searchClient.initIndex(SEARCH_INDEX_NAME)
-  const { hits } = await index.search(query)
+  // MeiliSearch
+  const queries = [{ params: { query }, indexName: SEARCH_INDEX_NAME }]
+  const { results } = (await searchClient.search(queries)) as Record<
+    string,
+    any
+  >
+  const { hits } = results[0]
+
+  // In case you want to use Algolia instead of MeiliSearch, uncomment the following lines and delete the above lines.
+
+  // const index = searchClient.initIndex(SEARCH_INDEX_NAME)
+  // const { hits } = await index.search(query)
+
   return hits
 }

--- a/src/lib/search-client.ts
+++ b/src/lib/search-client.ts
@@ -1,25 +1,25 @@
-// import { instantMeiliSearch } from "@meilisearch/instant-meilisearch"
+import { instantMeiliSearch } from "@meilisearch/instant-meilisearch"
 
-// const endpoint =
-//   process.env.NEXT_PUBLIC_SEARCH_ENDPOINT || "http://127.0.0.1:7700"
+const endpoint =
+  process.env.NEXT_PUBLIC_SEARCH_ENDPOINT || "http://127.0.0.1:7700"
 
-// const apiKey = process.env.NEXT_PUBLIC_SEARCH_API_KEY || "test_key"
+const apiKey = process.env.NEXT_PUBLIC_SEARCH_API_KEY || "test_key"
 
-// export const searchClient = instantMeiliSearch(endpoint, apiKey)
+export const searchClient = instantMeiliSearch(endpoint, apiKey)
 
-// export const SEARCH_INDEX_NAME =
-//   process.env.NEXT_PUBLIC_INDEX_NAME || "products"
+export const SEARCH_INDEX_NAME =
+  process.env.NEXT_PUBLIC_INDEX_NAME || "products"
 
 // If you want to use Algolia instead then uncomment the following lines, and delete the above lines
 // you should also install algoliasearch - yarn add algoliasearch
 
-import algoliasearch from "algoliasearch/lite"
+// import algoliasearch from "algoliasearch/lite"
 
-const appId = process.env.NEXT_PUBLIC_SEARCH_APP_ID || "test_app_id"
+// const appId = process.env.NEXT_PUBLIC_SEARCH_APP_ID || "test_app_id"
 
-const apiKey = process.env.NEXT_PUBLIC_SEARCH_API_KEY || "test_key"
+// const apiKey = process.env.NEXT_PUBLIC_SEARCH_API_KEY || "test_key"
 
-export const searchClient = algoliasearch(appId, apiKey)
+// export const searchClient = algoliasearch(appId, apiKey)
 
-export const SEARCH_INDEX_NAME =
-  process.env.NEXT_PUBLIC_INDEX_NAME || "products"
+// export const SEARCH_INDEX_NAME =
+//   process.env.NEXT_PUBLIC_INDEX_NAME || "products"

--- a/src/modules/search/templates/search-results-template/index.tsx
+++ b/src/modules/search/templates/search-results-template/index.tsx
@@ -40,14 +40,20 @@ const SearchResultsTemplate = ({ query, hits }: SearchResultsTemplateProps) => {
         </Link>
       </div>
       <div className="flex flex-col small:flex-row small:items-start py-6">
-        <RefinementList
-          refinementList={params}
-          setRefinementList={setParams}
-          sortBy={sortBy}
-          setSortBy={setSortBy}
-          search
-        />
-        <InfiniteProducts params={params} sortBy={sortBy} />
+        {hits.length > 0 ? (
+          <>
+            <RefinementList
+              refinementList={params}
+              setRefinementList={setParams}
+              sortBy={sortBy}
+              setSortBy={setSortBy}
+              search
+            />
+            <InfiniteProducts params={params} sortBy={sortBy} />
+          </>
+        ) : (
+          <Text className="ml-8 small:ml-14 mt-3">No results.</Text>
+        )}
       </div>
     </div>
   )

--- a/src/modules/search/templates/search-results-template/index.tsx
+++ b/src/modules/search/templates/search-results-template/index.tsx
@@ -19,7 +19,7 @@ const SearchResultsTemplate = ({ query, hits }: SearchResultsTemplateProps) => {
 
   useEffect(() => {
     setParams({
-      id: hits.map((h) => h.objectID),
+      id: hits.map((h) => (h.hasOwnProperty("objectId") ? h.objectID : h.id)),
     })
   }, [hits])
 

--- a/src/modules/search/templates/search-results-template/index.tsx
+++ b/src/modules/search/templates/search-results-template/index.tsx
@@ -19,7 +19,7 @@ const SearchResultsTemplate = ({ query, hits }: SearchResultsTemplateProps) => {
 
   useEffect(() => {
     setParams({
-      id: hits.map((h) => (h.hasOwnProperty("objectId") ? h.objectID : h.id)),
+      id: hits.map((h) => (h.hasOwnProperty("objectID") ? h.objectID : h.id)),
     })
   }, [hits])
 


### PR DESCRIPTION
In this PR:
- Adds MeiliSearch support to the search results page.
- Resets MeiliSearch as the default search provider.
- Adds in a '0 results' state for the search page.