### PR TITLE
fix: publishable api key header

### DIFF
--- a/src/lib/medusa-fetch/index.ts
+++ b/src/lib/medusa-fetch/index.ts
@@ -15,7 +15,7 @@ export default async function medusaRequest(
     method,
     headers: {
       "Content-Type": "application/json",
-      "x-publishable-key": MEDUSA_API_KEY,
+      "x-publishable-api-key": MEDUSA_API_KEY,
     },
     next: {
       revalidate: parseInt(REVALIDATE_WINDOW.toString()),


### PR DESCRIPTION
according to documentation, the correct name for api key header is x-publishable-api-key. Without -api- it does not work

https://docs.medusajs.com/api/store#publishable-api-key