### PR TITLE
fix: Toggling dark mode manually

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,7 @@
 const path = require("path")
 
 module.exports = {
+  darkMode: 'class',
   presets: [require("@medusajs/ui-preset")],
   content: [
     "./src/app/**/*.{js,ts,jsx,tsx}",


### PR DESCRIPTION
Without this option, delete yarn.lock and rebuild, the page color will be broken in the system dark mode.