### PR TITLE
fix: region and dynamic prices

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -4,7 +4,7 @@ NEXT_PUBLIC_MEDUSA_BACKEND_URL=http://localhost:9000
 # Your store URL, should be updated to where you are hosting your storefront.
 NEXT_PUBLIC_BASE_URL=http://localhost:8000
 
-# Your preferred default region. When the user region cannot be determined, this region will be used. ISO-2 lowercase format. 
+# Your preferred default region. When middleware cannot determine the user region from the "x-vercel-country" header, the default region will be used. ISO-2 lowercase format. 
 NEXT_PUBLIC_DEFAULT_REGION=us
 
 # Your Stripe public key. See – https://docs.medusajs.com/add-plugins/stripe

--- a/.env.template
+++ b/.env.template
@@ -4,6 +4,9 @@ NEXT_PUBLIC_MEDUSA_BACKEND_URL=http://localhost:9000
 # Your store URL, should be updated to where you are hosting your storefront.
 NEXT_PUBLIC_BASE_URL=http://localhost:8000
 
+# Your preferred default region. When the user region cannot be determined, this region will be used. ISO-2 lowercase format. 
+NEXT_PUBLIC_DEFAULT_REGION=us
+
 # Your Stripe public key. See – https://docs.medusajs.com/add-plugins/stripe
 NEXT_PUBLIC_STRIPE_KEY=
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,7 +2,7 @@ import { Region } from "@medusajs/medusa"
 import { NextRequest, NextResponse } from "next/server"
 
 const BACKEND_URL = process.env.NEXT_PUBLIC_MEDUSA_BACKEND_URL
-const DEFAULT_REGION = "us"
+const DEFAULT_REGION = process.env.NEXT_PUBLIC_DEFAULT_REGION || "us"
 
 /**
  * Fetches regions from Medusa and sets the region cookie.
@@ -28,6 +28,8 @@ async function getCountryCode(
       countryCode = vercelCountryCode
     } else if (regionMap.has(DEFAULT_REGION)) {
       countryCode = DEFAULT_REGION
+    } else if (regionMap.keys().next().value) {
+      countryCode = regionMap.keys().next().value
     }
 
     return countryCode

--- a/src/modules/products/templates/index.tsx
+++ b/src/modules/products/templates/index.tsx
@@ -9,6 +9,8 @@ import ProductTabs from "@modules/products/components/product-tabs"
 import RelatedProducts from "@modules/products/components/related-products"
 import ProductInfo from "@modules/products/templates/product-info"
 import SkeletonRelatedProducts from "@modules/skeletons/templates/skeleton-related-products"
+import { notFound } from "next/navigation"
+import ProductActionsWrapper from "./product-actions-wrapper"
 
 type ProductTemplateProps = {
   product: PricedProduct
@@ -21,6 +23,10 @@ const ProductTemplate: React.FC<ProductTemplateProps> = ({
   region,
   countryCode,
 }) => {
+  if (!product || !product.id) {
+    return notFound()
+  }
+
   return (
     <>
       <div className="content-container flex flex-col small:flex-row small:items-start py-6 relative">
@@ -33,7 +39,11 @@ const ProductTemplate: React.FC<ProductTemplateProps> = ({
         </div>
         <div className="flex flex-col small:sticky small:top-48 small:py-0 small:max-w-[300px] w-full py-8 gap-y-12">
           <ProductOnboardingCta />
-          <ProductActions product={product} region={region} />
+          <Suspense
+            fallback={<ProductActions product={product} region={region} />}
+          >
+            <ProductActionsWrapper id={product.id} region={region} />
+          </Suspense>
         </div>
       </div>
       <div className="content-container my-16 small:my-32">

--- a/src/modules/products/templates/product-actions-wrapper/index.tsx
+++ b/src/modules/products/templates/product-actions-wrapper/index.tsx
@@ -1,0 +1,22 @@
+import { retrievePricedProductById } from "@lib/data"
+import { Region } from "@medusajs/medusa"
+import ProductActions from "@modules/products/components/product-actions"
+
+/**
+ * Fetches real time pricing for a product and renders the product actions component.
+ */
+export default async function ProductActionsWrapper({
+  id,
+  region,
+}: {
+  id: string
+  region: Region
+}) {
+  const product = await retrievePricedProductById({ id, regionId: region.id })
+
+  if (!product) {
+    return null
+  }
+
+  return <ProductActions product={product} region={region} />
+}


### PR DESCRIPTION
In this PR:
- Default region is now an environment variable.
- When the user visits an url without region param, and the default region is not available on the Medusa server, it will default to the first available region. This prevents an endless redirect loop in case the default region is not set properly.
- On statically rendered product pages, prices are refetched on request time to check for user-specific pricing.