### PR TITLE
Search Result page query fix

### DIFF
--- a/src/modules/search/templates/search-results-template/index.tsx
+++ b/src/modules/search/templates/search-results-template/index.tsx
@@ -29,7 +29,7 @@ const SearchResultsTemplate = ({
         <div className="flex flex-col items-start">
           <Text className="text-ui-fg-muted">Search Results for:</Text>
           <Heading>
-            {query} ({ids.length})
+            {decodeURI(query)} ({ids.length})
           </Heading>
         </div>
         <LocalizedClientLink


### PR DESCRIPTION
the query string displayed for "Search Results for" should be decoded