### PR TITLE
Fix: not-found link to frontpage

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,6 +1,6 @@
 import { Metadata } from "next"
 
-import InteractiveLink from "@modules/common/components/interactive-link"
+import Link from "next/link"
 
 export const metadata: Metadata = {
   title: "404",
@@ -14,7 +14,7 @@ export default function NotFound() {
       <p className="text-small-regular text-ui-fg-base">
         The page you tried to access does not exist.
       </p>
-      <InteractiveLink href="/">Go to frontpage</InteractiveLink>
+      <Link href="/">Go to frontpage</Link>
     </div>
   )
 }

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -14,7 +14,16 @@ export default function NotFound() {
       <p className="text-small-regular text-ui-fg-base">
         The page you tried to access does not exist.
       </p>
-      <Link href="/">Go to frontpage</Link>
+      <Link
+        className="flex gap-x-1 items-center group"
+        href="/"
+      >
+        <Text className="text-ui-fg-interactive">Go to frontpage</Text>
+        <ArrowUpRightMini
+          className="group-hover:rotate-45 ease-in-out duration-150"
+          color="var(--fg-interactive)"
+        />
+      </Link>
     </div>
   )
 }


### PR DESCRIPTION
This PR aims to fix the not-found link to frontpage.

not-found.tsx file is using the InteractiveLink component to redirect to the frontpage, but the not-found page does not have access to the countryCode param, so right now is redirecting to "/undefined". To fix this issue, InteractiveLink can be replaced to the Link component from next/link.