### PR TITLE
Fix backorder and inStock computation

### DIFF
--- a/src/modules/products/components/product-actions/index.tsx
+++ b/src/modules/products/components/product-actions/index.tsx
@@ -95,13 +95,15 @@ export default function ProductActions({
 
   // check if the selected variant is in stock
   const inStock = useMemo(() => {
-    if (variant && !variant.inventory_quantity) {
-      return false
-    }
-
-    if (variant && variant.allow_backorder === false) {
+    // If backorder is allowed, product is always "in stock"
+    if (variant && variant.allow_backorder === true) {
       return true
     }
+    // If backorder is not allowed, then product is in stock only if inventory is greater than 0
+    if (variant && variant.inventory_quantity > 0) {
+      return true
+    }
+    return false
   }, [variant])
 
   const actionsRef = useRef<HTMLDivElement>(null)


### PR DESCRIPTION
There was a mistakes in the inStock computation.

Product is "virtually" in stock when backorder is allowed, so we shouldn't check for false value here.
Also, backorder need to be checked before inventory else a product with 0 inventory but with backorder enabled will not be in stock, as inventory will return false before it check for backorder.