### PR TITLE
Centralise the store name in store.config.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ node_modules
 .yarn
 .swc
 dump.rdb
+
+pnpm-lock.yaml

--- a/src/app/[countryCode]/(checkout)/layout.tsx
+++ b/src/app/[countryCode]/(checkout)/layout.tsx
@@ -1,6 +1,7 @@
 import LocalizedClientLink from "@modules/common/components/localized-client-link"
 import ChevronDown from "@modules/common/icons/chevron-down"
 import MedusaCTA from "@modules/layout/components/medusa-cta"
+import { store } from "@config"
 
 export default function CheckoutLayout({
   children,
@@ -27,7 +28,7 @@ export default function CheckoutLayout({
             href="/"
             className="txt-compact-xlarge-plus text-ui-fg-subtle hover:text-ui-fg-base uppercase"
           >
-            Medusa Store
+            {store.name}
           </LocalizedClientLink>
           <div className="flex-1 basis-0" />
         </nav>

--- a/src/app/[countryCode]/(main)/account/@dashboard/profile/page.tsx
+++ b/src/app/[countryCode]/(main)/account/@dashboard/profile/page.tsx
@@ -8,10 +8,11 @@ import ProfilePassword from "@modules/account/components/profile-password"
 
 import { getCustomer, listRegions } from "@lib/data"
 import { notFound } from "next/navigation"
+import { store } from "@config"
 
 export const metadata: Metadata = {
   title: "Profile",
-  description: "View and edit your Medusa Store profile.",
+  description: `View and edit your ${store.name} profile.`,
 }
 
 export default async function Profile() {

--- a/src/app/[countryCode]/(main)/account/@login/page.tsx
+++ b/src/app/[countryCode]/(main)/account/@login/page.tsx
@@ -1,10 +1,10 @@
 import { Metadata } from "next"
-
+import { store } from "@config"
 import LoginTemplate from "@modules/account/templates/login-template"
 
 export const metadata: Metadata = {
   title: "Sign in",
-  description: "Sign in to your Medusa Store account.",
+  description: `Sign in to your ${store.name} account.`,
 }
 
 export default function Login() {

--- a/src/app/[countryCode]/(main)/categories/[...category]/page.tsx
+++ b/src/app/[countryCode]/(main)/categories/[...category]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation"
 import { getCategoryByHandle, listCategories, listRegions } from "@lib/data"
 import CategoryTemplate from "@modules/categories/templates"
 import { SortOptions } from "@modules/store/components/refinement-list/sort-products"
+import { store } from "@config"
 
 type Props = {
   params: { category: string[]; countryCode: string }
@@ -53,7 +54,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       `${title} category.`
 
     return {
-      title: `${title} | Medusa Store`,
+      title: `${title} | ${store.name}`,
       description,
       alternates: {
         canonical: `${params.category.join("/")}`,

--- a/src/app/[countryCode]/(main)/collections/[handle]/page.tsx
+++ b/src/app/[countryCode]/(main)/collections/[handle]/page.tsx
@@ -8,6 +8,7 @@ import {
 } from "@lib/data"
 import CollectionTemplate from "@modules/collections/templates"
 import { SortOptions } from "@modules/store/components/refinement-list/sort-products"
+import { store } from "@config"
 
 type Props = {
   params: { handle: string; countryCode: string }
@@ -54,7 +55,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   }
 
   const metadata = {
-    title: `${collection.title} | Medusa Store`,
+    title: `${collection.title} | ${store.name}`,
     description: `${collection.title} collection`,
   } as Metadata
 

--- a/src/app/[countryCode]/(main)/products/[handle]/page.tsx
+++ b/src/app/[countryCode]/(main)/products/[handle]/page.tsx
@@ -2,6 +2,7 @@
 
 import { Metadata } from "next"
 import { notFound } from "next/navigation"
+import { store } from "@config"
 
 import {
   getProductByHandle,
@@ -58,10 +59,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   }
 
   return {
-    title: `${product.title} | Medusa Store`,
+    title: `${product.title} | ${store.name}`,
     description: `${product.title}`,
     openGraph: {
-      title: `${product.title} | Medusa Store`,
+      title: `${product.title} | ${store.name}`,
       description: `${product.title}`,
       images: product.thumbnail ? [product.thumbnail] : [],
     },

--- a/src/modules/account/components/register/index.tsx
+++ b/src/modules/account/components/register/index.tsx
@@ -8,6 +8,7 @@ import { signUp } from "@modules/account/actions"
 import ErrorMessage from "@modules/checkout/components/error-message"
 import { SubmitButton } from "@modules/checkout/components/submit-button"
 import LocalizedClientLink from "@modules/common/components/localized-client-link"
+import { store } from "@config"
 
 type Props = {
   setCurrentView: (view: LOGIN_VIEW) => void
@@ -19,10 +20,10 @@ const Register = ({ setCurrentView }: Props) => {
   return (
     <div className="max-w-sm flex flex-col items-center">
       <h1 className="text-large-semi uppercase mb-6">
-        Become a Medusa Store Member
+        Become a {store.name} Member
       </h1>
       <p className="text-center text-base-regular text-ui-fg-base mb-4">
-        Create your Medusa Store Member profile, and get access to an enhanced
+        Create your {store.name} Member profile, and get access to an enhanced
         shopping experience.
       </p>
       <form className="w-full flex flex-col" action={formAction}>
@@ -57,7 +58,7 @@ const Register = ({ setCurrentView }: Props) => {
         </div>
         <ErrorMessage error={message} />
         <span className="text-center text-ui-fg-base text-small-regular mt-6">
-          By creating an account, you agree to Medusa Store&apos;s{" "}
+          By creating an account, you agree to {store.name}&apos;s{" "}
           <LocalizedClientLink
             href="/content/privacy-policy"
             className="underline"

--- a/src/modules/layout/components/side-menu/index.tsx
+++ b/src/modules/layout/components/side-menu/index.tsx
@@ -5,6 +5,7 @@ import { ArrowRightMini, XMark } from "@medusajs/icons"
 import { Region } from "@medusajs/medusa"
 import { Text, clx, useToggleState } from "@medusajs/ui"
 import { Fragment } from "react"
+import { store } from "@config"
 
 import LocalizedClientLink from "@modules/common/components/localized-client-link"
 import CountrySelect from "../country-select"
@@ -84,7 +85,7 @@ const SideMenu = ({ regions }: { regions: Region[] | null }) => {
                         />
                       </div>
                       <Text className="flex justify-between txt-compact-small">
-                        © {new Date().getFullYear()} Medusa Store. All rights
+                        © {new Date().getFullYear()} {store.name}. All rights
                         reserved.
                       </Text>
                     </div>

--- a/src/modules/layout/templates/footer/index.tsx
+++ b/src/modules/layout/templates/footer/index.tsx
@@ -1,6 +1,7 @@
 import { Text, clx } from "@medusajs/ui"
 
 import { getCategoriesList, getCollectionsList } from "@lib/data"
+import { store } from "@config"
 
 import LocalizedClientLink from "@modules/common/components/localized-client-link"
 import MedusaCTA from "../../components/medusa-cta"
@@ -31,7 +32,7 @@ export default async function Footer() {
               href="/"
               className="txt-compact-xlarge-plus text-ui-fg-subtle hover:text-ui-fg-base uppercase"
             >
-              Medusa Store
+              {store.name}
             </LocalizedClientLink>
           </div>
           <div className="text-small-regular gap-10 md:gap-x-16 grid grid-cols-2 sm:grid-cols-3">
@@ -153,7 +154,7 @@ export default async function Footer() {
         </div>
         <div className="flex w-full mb-16 justify-between text-ui-fg-muted">
           <Text className="txt-compact-small">
-            © {new Date().getFullYear()} Medusa Store. All rights reserved.
+            © {new Date().getFullYear()} {store.name}. All rights reserved.
           </Text>
           <MedusaCTA />
         </div>

--- a/src/modules/layout/templates/nav/index.tsx
+++ b/src/modules/layout/templates/nav/index.tsx
@@ -5,6 +5,7 @@ import { listRegions } from "@lib/data"
 import LocalizedClientLink from "@modules/common/components/localized-client-link"
 import CartButton from "@modules/layout/components/cart-button"
 import SideMenu from "@modules/layout/components/side-menu"
+import { store } from "@config"
 
 export default async function Nav() {
   const regions = await listRegions().then((regions) => regions)
@@ -24,7 +25,7 @@ export default async function Nav() {
               href="/"
               className="txt-compact-xlarge-plus hover:text-ui-fg-base uppercase"
             >
-              Medusa Store
+              {store.name}
             </LocalizedClientLink>
           </div>
 

--- a/store.config.json
+++ b/store.config.json
@@ -1,5 +1,8 @@
 {
   "features": {
     "search": false
+  },
+  "store": {
+    "name": "Medusa Store"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,8 @@
     "paths": {
       "@lib/*": ["lib/*"],
       "@modules/*": ["modules/*"],
-      "@pages/*": ["pages/*"]
+      "@pages/*": ["pages/*"],
+      "@config": ["../store.config.json"]
     },
     "plugins": [
       {


### PR DESCRIPTION
Currently `Medusa Store` is hard-coded in templates all over and it would be better to centralise it in `store.config.json` instead. This will allow developers to quickly use their store name without modifying templates and keeping in sync upstream.