### PR TITLE
fix: checkout breaking when Stripe is the only payment provider

### DIFF
--- a/src/modules/checkout/components/payment-wrapper/index.tsx
+++ b/src/modules/checkout/components/payment-wrapper/index.tsx
@@ -5,11 +5,14 @@ import { loadStripe } from "@stripe/stripe-js"
 import React from "react"
 import StripeWrapper from "./stripe-wrapper"
 import { PayPalScriptProvider } from "@paypal/react-paypal-js"
+import { createContext } from "react"
 
 type WrapperProps = {
   cart: Omit<Cart, "refundable_amount" | "refunded_total">
   children: React.ReactNode
 }
+
+export const StripeContext = createContext(false)
 
 const stripeKey = process.env.NEXT_PUBLIC_STRIPE_KEY
 const stripePromise = stripeKey ? loadStripe(stripeKey) : null
@@ -23,13 +26,15 @@ const Wrapper: React.FC<WrapperProps> = ({ cart, children }) => {
 
   if (isStripe && paymentSession && stripePromise) {
     return (
-      <StripeWrapper
-        paymentSession={paymentSession}
-        stripeKey={stripeKey}
-        stripePromise={stripePromise}
-      >
-        {children}
-      </StripeWrapper>
+      <StripeContext.Provider value={true}>
+        <StripeWrapper
+          paymentSession={paymentSession}
+          stripeKey={stripeKey}
+          stripePromise={stripePromise}
+        >
+          {children}
+        </StripeWrapper>
+      </StripeContext.Provider>
     )
   }
 

--- a/src/modules/checkout/components/payment/index.tsx
+++ b/src/modules/checkout/components/payment/index.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useCallback, useEffect, useMemo, useState } from "react"
+import { useCallback, useContext, useEffect, useMemo, useState } from "react"
 import { usePathname, useRouter, useSearchParams } from "next/navigation"
 import { RadioGroup } from "@headlessui/react"
 import ErrorMessage from "@modules/checkout/components/error-message"
@@ -15,6 +15,7 @@ import Spinner from "@modules/common/icons/spinner"
 import PaymentContainer from "@modules/checkout/components/payment-container"
 import { setPaymentMethod } from "@modules/checkout/actions"
 import { paymentInfoMap } from "@lib/constants"
+import { StripeContext } from "@modules/checkout/components/payment-wrapper"
 
 const Payment = ({
   cart,
@@ -33,6 +34,7 @@ const Payment = ({
   const isOpen = searchParams.get("step") === "payment"
 
   const isStripe = cart?.payment_session?.provider_id === "stripe"
+  const stripeReady = useContext(StripeContext)
 
   const paymentReady =
     cart?.payment_session && cart?.shipping_methods.length !== 0
@@ -149,7 +151,7 @@ const Payment = ({
                 })}
             </RadioGroup>
 
-            {isStripe && (
+            {isStripe && stripeReady && (
               <div className="mt-5 transition-all duration-150 ease-in-out">
                 <Text className="txt-medium-plus text-ui-fg-base mb-1">
                   Enter your card details:


### PR DESCRIPTION
**In this PR:**

Fixes https://github.com/medusajs/nextjs-starter-medusa/issues/247 where Stripe elements tried to render before the Elements context was properly loaded.

**Solution:**

Adds in a `StripeContext` provider that returns `true` when the Elements context is ready. You can hook into this context to conditionally render Stripe elements in your checkout form. 