### PR TITLE
fix: enforce light mode

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,7 @@
 const path = require("path")
 
 module.exports = {
+  darkMode: "class",
   presets: [require("@medusajs/ui-preset")],
   content: [
     "./src/app/**/*.{js,ts,jsx,tsx}",


### PR DESCRIPTION
System dark mode was causing issues with newer Tailwind versions. This PR ensures light mode regardless of the user system setting.