### PR TITLE
Retrieving available shipping methods using cart id to meet requirements

### DIFF
--- a/src/lib/data/index.ts
+++ b/src/lib/data/index.ts
@@ -222,6 +222,21 @@ export const listShippingMethods = cache(async function listShippingMethods(
     })
 })
 
+/**
+ * List the available shipping methods using the cart id
+ * @param cartId The Cart ID
+ * @returns
+ */
+export async function listCartShippingMethods(cartId: string) {
+  return medusaClient.shippingOptions
+    .listCartOptions(cartId)
+    .then(({ shipping_options }) => shipping_options)
+    .catch((err) => {
+      console.log(err)
+      return null
+    })
+}
+
 export async function addShippingMethod({
   cartId,
   shippingMethodId,

--- a/src/modules/checkout/templates/checkout-form/index.tsx
+++ b/src/modules/checkout/templates/checkout-form/index.tsx
@@ -1,15 +1,15 @@
-import Addresses from "@modules/checkout/components/addresses"
-import Shipping from "@modules/checkout/components/shipping"
-import Payment from "@modules/checkout/components/payment"
-import Review from "@modules/checkout/components/review"
 import {
   createPaymentSessions,
   getCustomer,
-  listShippingMethods,
+  listCartShippingMethods
 } from "@lib/data"
+import { getCheckoutStep } from "@lib/util/get-checkout-step"
+import Addresses from "@modules/checkout/components/addresses"
+import Payment from "@modules/checkout/components/payment"
+import Review from "@modules/checkout/components/review"
+import Shipping from "@modules/checkout/components/shipping"
 import { cookies } from "next/headers"
 import { CartWithCheckoutStep } from "types/global"
-import { getCheckoutStep } from "@lib/util/get-checkout-step"
 
 export default async function CheckoutForm() {
   const cartId = cookies().get("_medusa_cart_id")?.value
@@ -30,8 +30,8 @@ export default async function CheckoutForm() {
   cart.checkout_step = cart && getCheckoutStep(cart)
 
   // get available shipping methods
-  const availableShippingMethods = await listShippingMethods(
-    cart.region_id
+  const availableShippingMethods = await listCartShippingMethods(
+    cart.id
   ).then((methods) => methods?.filter((m) => !m.is_return))
 
   if (!availableShippingMethods) {


### PR DESCRIPTION
Retrieving the shipping methods using `medusaClient.shippingOptions.list` does not fulfil the shipping options requirements(min and max)

Changing to retrieving the shipping options using the `medusaClient.shippingOptions.listCartOptions`

Scenario:
A shipping option should only be applicable(shown) if cart has a total of  >= 20 and <= 80. 