### PR TITLE
fix: use listCartOptions instead of list

### DIFF
--- a/src/lib/data/index.ts
+++ b/src/lib/data/index.ts
@@ -199,22 +199,11 @@ export const retrieveOrder = cache(async function (id: string) {
 })
 
 // Shipping actions
-export const listShippingMethods = cache(async function listShippingMethods(
-  regionId: string,
-  productIds?: string[]
-) {
+export const listCartShippingMethods = cache(async function (cartId: string) {
   const headers = getMedusaHeaders(["shipping"])
 
-  const product_ids = productIds?.join(",")
-
   return medusaClient.shippingOptions
-    .list(
-      {
-        region_id: regionId,
-        product_ids,
-      },
-      headers
-    )
+    .listCartOptions(cartId, headers)
     .then(({ shipping_options }) => shipping_options)
     .catch((err) => {
       console.log(err)

--- a/src/modules/checkout/templates/checkout-form/index.tsx
+++ b/src/modules/checkout/templates/checkout-form/index.tsx
@@ -1,15 +1,15 @@
-import Addresses from "@modules/checkout/components/addresses"
-import Shipping from "@modules/checkout/components/shipping"
-import Payment from "@modules/checkout/components/payment"
-import Review from "@modules/checkout/components/review"
 import {
   createPaymentSessions,
   getCustomer,
-  listShippingMethods,
+  listCartShippingMethods,
 } from "@lib/data"
+import { getCheckoutStep } from "@lib/util/get-checkout-step"
+import Addresses from "@modules/checkout/components/addresses"
+import Payment from "@modules/checkout/components/payment"
+import Review from "@modules/checkout/components/review"
+import Shipping from "@modules/checkout/components/shipping"
 import { cookies } from "next/headers"
 import { CartWithCheckoutStep } from "types/global"
-import { getCheckoutStep } from "@lib/util/get-checkout-step"
 
 export default async function CheckoutForm() {
   const cartId = cookies().get("_medusa_cart_id")?.value
@@ -30,9 +30,9 @@ export default async function CheckoutForm() {
   cart.checkout_step = cart && getCheckoutStep(cart)
 
   // get available shipping methods
-  const availableShippingMethods = await listShippingMethods(
-    cart.region_id
-  ).then((methods) => methods?.filter((m) => !m.is_return))
+  const availableShippingMethods = await listCartShippingMethods(cart.id).then(
+    (methods) => methods?.filter((m) => !m.is_return)
+  )
 
   if (!availableShippingMethods) {
     return null


### PR DESCRIPTION
Fixes an issue where shipping options with `price_type: calculated` would have no `amount`. The `listShippingOptions` fetch was using the wrong method.