### PR TITLE
fix: payment provider ID detection

### DIFF
--- a/src/modules/checkout/components/payment-button/index.tsx
+++ b/src/modules/checkout/components/payment-button/index.tsx
@@ -39,7 +39,7 @@ const PaymentButton: React.FC<PaymentButtonProps> = ({
   const paymentSession = cart.payment_collection?.payment_sessions?.[0]
 
   switch (paymentSession?.provider_id) {
-    case "stripe":
+    case "pp_stripe_stripe":
       return (
         <StripePaymentButton
           notReady={notReady}

--- a/src/modules/checkout/components/payment-button/index.tsx
+++ b/src/modules/checkout/components/payment-button/index.tsx
@@ -38,8 +38,8 @@ const PaymentButton: React.FC<PaymentButtonProps> = ({
 
   const paymentSession = cart.payment_collection?.payment_sessions?.[0]
 
-  switch (paymentSession?.provider_id) {
-    case "pp_stripe_stripe":
+  switch (true) {
+    case paymentSession?.provider_id.startsWith("pp_stripe"):
       return (
         <StripePaymentButton
           notReady={notReady}
@@ -47,12 +47,12 @@ const PaymentButton: React.FC<PaymentButtonProps> = ({
           data-testid={dataTestId}
         />
       )
-    case "manual":
-    case "pp_system_default":
+    case paymentSession?.provider_id.startsWith("manual"):
+    case paymentSession?.provider_id.startsWith("pp_system_default"):
       return (
         <ManualTestPaymentButton notReady={notReady} data-testid={dataTestId} />
       )
-    case "paypal":
+    case paymentSession?.provider_id.startsWith("pp_paypal"):
       return (
         <PayPalPaymentButton
           notReady={notReady}

--- a/src/modules/checkout/components/payment-button/index.tsx
+++ b/src/modules/checkout/components/payment-button/index.tsx
@@ -39,7 +39,7 @@ const PaymentButton: React.FC<PaymentButtonProps> = ({
   const paymentSession = cart.payment_collection?.payment_sessions?.[0]
 
   switch (true) {
-    case paymentSession?.provider_id.startsWith("pp_stripe"):
+    case paymentSession?.provider_id.startsWith("pp_stripe_"):
       return (
         <StripePaymentButton
           notReady={notReady}


### PR DESCRIPTION
- Change payment provider ID switch cases to check if a provider ID starts with a value. That's because the last part of the provider ID is configurable by the developer in the Medusa config, so it may be different than what we expect.
- Fix stripe's provider ID to start with `pp_stripe_`