### PR TITLE
Fix instantMeiliSearch searchClient export

### DIFF
--- a/src/lib/search-client.ts
+++ b/src/lib/search-client.ts
@@ -5,7 +5,7 @@ const endpoint =
 
 const apiKey = process.env.NEXT_PUBLIC_SEARCH_API_KEY || "test_key"
 
-export const searchClient = instantMeiliSearch(endpoint, apiKey)
+export const { searchClient } = instantMeiliSearch(endpoint, apiKey)
 
 export const SEARCH_INDEX_NAME =
   process.env.NEXT_PUBLIC_INDEX_NAME || "products"


### PR DESCRIPTION
Error: The `searchClient` must implement a `search` method.