### PR TITLE
Fix: ensure valid pageParam to prevent negative offset in pagination

### DIFF
--- a/src/lib/data/products.ts
+++ b/src/lib/data/products.ts
@@ -54,7 +54,8 @@ export const getProductsList = cache(async function ({
   queryParams?: HttpTypes.FindParams & HttpTypes.StoreProductParams
 }> {
   const limit = queryParams?.limit || 12
-  const offset = (pageParam - 1) * limit
+  const validPageParam = Math.max(pageParam, 1) // Ensure pageParam is always atleast `1`
+  const offset = (validPageParam - 1) * limit
   const region = await getRegion(countryCode)
 
   if (!region) {


### PR DESCRIPTION
Fixes [#9432](https://github.com/medusajs/medusa/issues/9432#issue-2562092203)

This PR fixes the bug in product pagination by ensuring that pageParam is always valid (i.e., greater than or equal to 1) before calculating the offset. It prevents negative values from being passed to the offset, which was causing a runtime error.

Fix Details:
Instead of just removing -1 from the offset calculation, I used Math.max(1, pageParam) to guarantee that pageParam will always be at least 1. This ensures that the offset calculation is never negative while keeping the existing logic intact.