### PR TITLE
Fix: Optimize product page static generation

### DIFF
--- a/src/app/[countryCode]/(main)/products/[handle]/page.tsx
+++ b/src/app/[countryCode]/(main)/products/[handle]/page.tsx
@@ -35,7 +35,11 @@ export async function generateStaticParams() {
       .flat()
       .filter((param) => param.handle)
   } catch (error) {
-    console.error("Error generating static params:", error)
+    console.error(
+      `Failed to generate static paths for product pages: ${
+        error instanceof Error ? error.message : "Unknown error"
+      }.`
+    )
     return []
   }
 }

--- a/src/app/[countryCode]/(main)/products/[handle]/page.tsx
+++ b/src/app/[countryCode]/(main)/products/[handle]/page.tsx
@@ -3,43 +3,41 @@ import { notFound } from "next/navigation"
 
 import ProductTemplate from "@modules/products/templates"
 import { getRegion, listRegions } from "@lib/data/regions"
-import { getProductByHandle, getProductsList } from "@lib/data/products"
+import { getProductByHandle } from "@lib/data/products"
+import { sdk } from "@lib/config"
 
 type Props = {
   params: { countryCode: string; handle: string }
 }
 
 export async function generateStaticParams() {
-  const countryCodes = await listRegions().then(
-    (regions) =>
-      regions
-        ?.map((r) => r.countries?.map((c) => c.iso_2))
-        .flat()
-        .filter(Boolean) as string[]
-  )
-
-  if (!countryCodes) {
-    return null
-  }
-
-  const products = await Promise.all(
-    countryCodes.map((countryCode) => {
-      return getProductsList({ countryCode })
-    })
-  ).then((responses) =>
-    responses.map(({ response }) => response.products).flat()
-  )
-
-  const staticParams = countryCodes
-    ?.map((countryCode) =>
-      products.map((product) => ({
-        countryCode,
-        handle: product.handle,
-      }))
+  try {
+    const countryCodes = await listRegions().then((regions) =>
+      regions?.map((r) => r.countries?.map((c) => c.iso_2)).flat()
     )
-    .flat()
 
-  return staticParams
+    if (!countryCodes) {
+      return []
+    }
+
+    const { products } = await sdk.store.product.list(
+      { fields: "handle" },
+      { next: { tags: ["products"] } }
+    )
+
+    return countryCodes
+      .map((countryCode) =>
+        products.map((product) => ({
+          countryCode,
+          handle: product.handle,
+        }))
+      )
+      .flat()
+      .filter((param) => param.handle)
+  } catch (error) {
+    console.error("Error generating static params:", error)
+    return []
+  }
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {


### PR DESCRIPTION
#391 
This pull request includes changes to fix the error caused by `generateStaticParams` in `src/app/[countryCode]/(main)/products/[handle]/page.tsx`.

Problem:
- Production build fails with DYNAMIC_SERVER_USAGE error
- Multiple unnecessary API calls during static generation

Fix:
- Single optimized SDK call for product handles
- Improved error handling
- Maintains Next.js caching patterns