### PR TITLE
Fix Product List Pagination to Include First Page of Results

### DIFF
--- a/src/lib/data/products.ts
+++ b/src/lib/data/products.ts
@@ -41,7 +41,7 @@ export const getProductByHandle = cache(async function (
 })
 
 export const getProductsList = cache(async function ({
-  pageParam = 1,
+  pageParam = 0,
   queryParams,
   countryCode,
 }: {


### PR DESCRIPTION
This PR fixes a pagination issue in the getProductsList function. By updating the default pageParam from 1 to 0, we ensure the function starts pagination from the first page of results. Previously, starting at pageParam = 1 caused an offset that skipped the initial set of products. Now, pagination will begin correctly at the first record set, providing a complete list of products without omissions.

**Changes:**
- I updated the default pageParam from 1 to 0 to avoid skipping the first page of records.