### PR TITLE
fix: replace decimal separator in order confirmation

### DIFF
--- a/src/modules/order/components/shipping-details/index.tsx
+++ b/src/modules/order/components/shipping-details/index.tsx
@@ -62,7 +62,7 @@ const ShippingDetails = ({ order }: ShippingDetailsProps) => {
               currency_code: order.currency_code,
             })
               .replace(/,/g, "")
-              .replace(/\./g, ",")}
+              .replace(/\./g, ".")}
             )
           </Text>
         </div>

--- a/src/modules/order/components/shipping-details/index.tsx
+++ b/src/modules/order/components/shipping-details/index.tsx
@@ -60,9 +60,7 @@ const ShippingDetails = ({ order }: ShippingDetailsProps) => {
             {convertToLocale({
               amount: order.shipping_methods?.[0].total ?? 0,
               currency_code: order.currency_code,
-            })
-              .replace(/,/g, "")
-              .replace(/\./g, ".")}
+            })}
             )
           </Text>
         </div>


### PR DESCRIPTION
When my shipping method is $30 for instance, It was $30,00 and this PR fixes it to $30.00