### PR TITLE
Fix: add missing phone for billing address

### DIFF
--- a/src/modules/account/components/profile-billing-address/index.tsx
+++ b/src/modules/account/components/profile-billing-address/index.tsx
@@ -124,6 +124,15 @@ const ProfileBillingAddress: React.FC<MyInformationProps> = ({
             data-testid="billing-company-input"
           />
           <Input
+            label="Phone"
+            name="phone"
+            type="phone"
+            autoComplete="phone"
+            required
+            defaultValue={billingAddress?.phone ?? customer?.phone ?? ""}
+            data-testid="billing-phone-input"
+          />
+          <Input
             label="Address"
             name="address_1"
             defaultValue={billingAddress?.address_1 || undefined}


### PR DESCRIPTION
Phone number is required from the BE side:
"Error: Invalid request: Expected type: 'string' for field 'phone', got: 'null'"}
