### PR TITLE
Fix translate label on autofill

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -18,6 +18,7 @@
   }
 
   input:focus ~ label,
+  input:-webkit-autofill ~ label,
   input:not(:placeholder-shown) ~ label {
     @apply -translate-y-2 text-xsmall-regular;
   }


### PR DESCRIPTION
When email and password is autofill the translate doesn't apply on label till we click on the webpage