### PR TITLE
Fixed broken links in .env.template

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,7 +1,7 @@
-# Your Medusa backend, should be updated to where you are hosting your server. Remember to update CORS settings for your server. See – https://docs.medusajs.com/usage/configurations#admin_cors-and-store_cors
+# Your Medusa backend, should be updated to where you are hosting your server. Remember to update CORS settings for your server. See – https://docs.medusajs.com/resources/storefront-development/tips#configure-cors
 MEDUSA_BACKEND_URL=http://localhost:9000
 
-# Your publishable key that can be attached to sales channels. See - https://docs.medusajs.com/development/publishable-api-keys
+# Your publishable key that can be attached to sales channels. See - https://docs.medusajs.com/v1/development/publishable-api-keys
 NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY=pk_test
 
 # Your store URL, should be updated to where you are hosting your storefront.
@@ -10,7 +10,7 @@ NEXT_PUBLIC_BASE_URL=http://localhost:8000
 # Your preferred default region. When middleware cannot determine the user region from the "x-vercel-country" header, the default region will be used. ISO-2 lowercase format. 
 NEXT_PUBLIC_DEFAULT_REGION=us
 
-# Your Stripe public key. See – https://docs.medusajs.com/add-plugins/stripe
+# Your Stripe public key. See – https://docs.medusajs.com/v1/plugins/payment/stripe
 NEXT_PUBLIC_STRIPE_KEY=
 
 # Your Next.js revalidation secret. See – https://nextjs.org/docs/app/building-your-application/data-fetching/fetching-caching-and-revalidating#on-demand-revalidation


### PR DESCRIPTION
Medusa has recently introduced a v2 documentation, meaning that current links to Medusa Docs in .env.local are now broken. 

The links on this PR point out to the correct resources to help users set up their environment variables.