### PR TITLE
fix: Mobile product options select showing when there's no options

### DIFF
--- a/src/lib/util/product.ts
+++ b/src/lib/util/product.ts
@@ -1,0 +1,5 @@
+import { HttpTypes } from "@medusajs/types";
+
+export const isSimpleProduct = (product: HttpTypes.StoreProduct): boolean => {
+    return product.options?.length === 1 && product.options[0].values?.length === 1;
+}

--- a/src/modules/products/components/product-actions/mobile-actions.tsx
+++ b/src/modules/products/components/product-actions/mobile-actions.tsx
@@ -9,6 +9,7 @@ import X from "@modules/common/icons/x"
 import { getProductPrice } from "@lib/util/get-product-price"
 import OptionSelect from "./option-select"
 import { HttpTypes } from "@medusajs/types"
+import { isSimpleProduct } from "@lib/util/product"
 
 type MobileActionsProps = {
   product: HttpTypes.StoreProduct
@@ -48,6 +49,8 @@ const MobileActions: React.FC<MobileActionsProps> = ({
 
     return variantPrice || cheapestPrice || null
   }, [price])
+
+  const isSimple = isSimpleProduct(product)
 
   return (
     <>
@@ -95,8 +98,10 @@ const MobileActions: React.FC<MobileActionsProps> = ({
                 <div></div>
               )}
             </div>
-            <div className="grid grid-cols-2 w-full gap-x-4">
-              <Button
+            <div className={clx("grid grid-cols-2 w-full gap-x-4", {
+              "!grid-cols-1": isSimple
+            })}>
+              {!isSimple && <Button
                 onClick={open}
                 variant="secondary"
                 className="w-full"
@@ -110,7 +115,7 @@ const MobileActions: React.FC<MobileActionsProps> = ({
                   </span>
                   <ChevronDown />
                 </div>
-              </Button>
+              </Button>}
               <Button
                 onClick={handleAddToCart}
                 disabled={!inStock || !variant}


### PR DESCRIPTION
mobile-actions.tsx: On mobile, for a product with only one variant (and one set of options), there shouldn't be any option select:

**Before**

<img width="385" alt="image" src="https://github.com/user-attachments/assets/40e2f339-72ee-4ce4-a946-f356453172df" />

<img width="383" alt="image2" src="https://github.com/user-attachments/assets/20c1f14c-9f12-4d25-ab43-eae5f40148e0" />



**After**

<img width="385" alt="image3" src="https://github.com/user-attachments/assets/c38cc9d0-0009-4515-9ecf-2397d171fec7" />
