### PR TITLE
fix: customer server action & cache

### DIFF
--- a/src/lib/data/customer.ts
+++ b/src/lib/data/customer.ts
@@ -129,7 +129,6 @@ export async function login(_currentState: unknown, formData: FormData) {
 export async function signout(countryCode: string) {
   await sdk.auth.logout()
   removeAuthToken()
-  revalidateTag("auth")
   revalidateTag("customer")
   redirect(`/${countryCode}/account`)
 }

--- a/src/lib/data/customer.ts
+++ b/src/lib/data/customer.ts
@@ -127,9 +127,10 @@ export async function login(_currentState: unknown, formData: FormData) {
 }
 
 export async function signout(countryCode: string) {
+  const customerCacheTag = await getCacheTag("customers")
   await sdk.auth.logout()
   removeAuthToken()
-  revalidateTag("customer")
+  revalidateTag(customerCacheTag)
   redirect(`/${countryCode}/account`)
 }
 

--- a/src/lib/data/customer.ts
+++ b/src/lib/data/customer.ts
@@ -16,8 +16,12 @@ import {
 
 export const retrieveCustomer =
   async (): Promise<HttpTypes.StoreCustomer | null> => {
+    const authHeaders = await getAuthHeaders()
+
+    if (!authHeaders) return null
+
     const headers = {
-      ...(await getAuthHeaders()),
+      ...authHeaders,
     }
 
     const next = {


### PR DESCRIPTION
- Use dynamic customer cache tag to unvalidate customer in signout function
- Prevent Customer API call if no JWT is set (and avoid 401)
- Remove unnecessary `customer` cache tag
- Remove unnecessary `auth` cache tag
