### PR TITLE
Fix cache revalidation in customer actions

### DIFF
--- a/src/lib/data/customer.ts
+++ b/src/lib/data/customer.ts
@@ -125,8 +125,8 @@ export async function login(_currentState: unknown, formData: FormData) {
 export async function signout(countryCode: string) {
   await sdk.auth.logout()
   removeAuthToken()
-  revalidateTag("auth")
-  revalidateTag("customer")
+  const customerCacheTag = await getCacheTag("customers")
+  revalidateTag(customerCacheTag)
   redirect(`/${countryCode}/account`)
 }
 
@@ -141,7 +141,8 @@ export async function transferCart() {
 
   await sdk.store.cart.transferCart(cartId, {}, headers)
 
-  revalidateTag("cart")
+  const cartCacheTag = await getCacheTag("carts")
+  revalidateTag(cartCacheTag)
 }
 
 export const addCustomerAddress = async (


### PR DESCRIPTION
The functions `signout` and `transferCart` use hard-coded tags for revalidation that do not include the cache id. Because of this the transfer cart banner is not hidden on success and signing out leads to a 404, requiring a manual refresh. This PR addresses that.

The hardcoded "auth" tag also has no associated queries, so it has been removed.