### PR TITLE
fix: generateStaticParams for products/[handle]

### DIFF
--- a/src/app/[countryCode]/(main)/products/[handle]/page.tsx
+++ b/src/app/[countryCode]/(main)/products/[handle]/page.tsx
@@ -27,7 +27,7 @@ export async function generateStaticParams() {
 
       return {
         country,
-        products: response.products || [],
+        products: response.products,
       }
     })
 

--- a/src/app/[countryCode]/(main)/products/[handle]/page.tsx
+++ b/src/app/[countryCode]/(main)/products/[handle]/page.tsx
@@ -22,7 +22,6 @@ export async function generateStaticParams() {
       const { response } = await listProducts({
         countryCode: country,
         queryParams: { limit: 100, fields: "handle" },
-        isStatic: true,
       })
 
       return {

--- a/src/app/[countryCode]/(main)/products/[handle]/page.tsx
+++ b/src/app/[countryCode]/(main)/products/[handle]/page.tsx
@@ -27,7 +27,7 @@ export async function generateStaticParams() {
 
       return {
         country,
-        products: response.products?.filter((p) => p.handle) || [],
+        products: response.products || [],
       }
     })
 

--- a/src/lib/data/cookies.ts
+++ b/src/lib/data/cookies.ts
@@ -4,14 +4,18 @@ import { cookies as nextCookies } from "next/headers"
 export const getAuthHeaders = async (): Promise<
   { authorization: string } | {}
 > => {
-  const cookies = await nextCookies()
-  const token = cookies.get("_medusa_jwt")?.value
+  try {
+    const cookies = await nextCookies()
+    const token = cookies.get("_medusa_jwt")?.value
 
-  if (!token) {
+    if (!token) {
+      return {}
+    }
+
+    return { authorization: `Bearer ${token}` }
+  } catch {
     return {}
   }
-
-  return { authorization: `Bearer ${token}` }
 }
 
 export const getCacheTag = async (tag: string): Promise<string> => {

--- a/src/lib/data/products.ts
+++ b/src/lib/data/products.ts
@@ -12,13 +12,11 @@ export const listProducts = async ({
   queryParams,
   countryCode,
   regionId,
-  isStatic = false,
 }: {
   pageParam?: number
   queryParams?: HttpTypes.FindParams & HttpTypes.StoreProductParams
   countryCode?: string
   regionId?: string
-  isStatic?: boolean
 }): Promise<{
   response: { products: HttpTypes.StoreProduct[]; count: number }
   nextPage: number | null
@@ -30,7 +28,7 @@ export const listProducts = async ({
 
   const limit = queryParams?.limit || 12
   const _pageParam = Math.max(pageParam, 1)
-  const offset = (_pageParam === 1) ? 0 : (_pageParam - 1) * limit;
+  const offset = _pageParam === 1 ? 0 : (_pageParam - 1) * limit
 
   let region: HttpTypes.StoreRegion | undefined | null
 
@@ -47,11 +45,9 @@ export const listProducts = async ({
     }
   }
 
-  const headers = isStatic
-    ? {}
-    : {
-        ...(await getAuthHeaders()),
-      }
+  const headers = {
+    ...(await getAuthHeaders()),
+  }
 
   const next = {
     ...(await getCacheOptions("products")),

--- a/src/lib/data/products.ts
+++ b/src/lib/data/products.ts
@@ -12,11 +12,13 @@ export const listProducts = async ({
   queryParams,
   countryCode,
   regionId,
+  isStatic = false,
 }: {
   pageParam?: number
   queryParams?: HttpTypes.FindParams & HttpTypes.StoreProductParams
   countryCode?: string
   regionId?: string
+  isStatic?: boolean
 }): Promise<{
   response: { products: HttpTypes.StoreProduct[]; count: number }
   nextPage: number | null
@@ -45,9 +47,11 @@ export const listProducts = async ({
     }
   }
 
-  const headers = {
-    ...(await getAuthHeaders()),
-  }
+  const headers = isStatic
+    ? {}
+    : {
+        ...(await getAuthHeaders()),
+      }
 
   const next = {
     ...(await getCacheOptions("products")),


### PR DESCRIPTION
This PR fixes and enhances the generateStaticParams function for product pages, fixing and enabling builds for all countries. Changed product limit to 100 per country from the default 12.