### PR TITLE
fix: Support both MEDUSA_BACKEND_URL and NEXT_PUBLIC_MEDUSA_BACKEND_URL in middleware

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,5 +1,10 @@
 # Your Medusa backend, should be updated to where you are hosting your server. Remember to update CORS settings for your server. See – https://docs.medusajs.com/usage/configurations#admin_cors-and-store_cors
+# Used for server-side code (middleware)
 MEDUSA_BACKEND_URL=http://localhost:9000
+
+# Used for client-side code. For convenience, you can set it to the same value as MEDUSA_BACKEND_URL
+# The middleware will also check this value if MEDUSA_BACKEND_URL is not set
+NEXT_PUBLIC_MEDUSA_BACKEND_URL=http://localhost:9000
 
 # Your publishable key that can be attached to sales channels. See - https://docs.medusajs.com/development/publishable-api-keys
 NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY=pk_test
@@ -10,7 +15,7 @@ NEXT_PUBLIC_BASE_URL=http://localhost:8000
 # Your preferred default region. When middleware cannot determine the user region from the "x-vercel-country" header, the default region will be used. ISO-2 lowercase format. 
 NEXT_PUBLIC_DEFAULT_REGION=us
 
-# Your Stripe public key. See – https://docs.medusajs.com/add-plugins/stripe
+# Your Stripe public key. See – https://docs.medusajs.com/add-plugins/stripe
 NEXT_PUBLIC_STRIPE_KEY=
 
 # Your Next.js revalidation secret. See – https://nextjs.org/docs/app/building-your-application/data-fetching/fetching-caching-and-revalidating#on-demand-revalidation

--- a/README.md
+++ b/README.md
@@ -76,6 +76,15 @@ cd nextjs-starter-medusa/
 mv .env.template .env.local
 ```
 
+#### Environment Variables
+
+This starter uses the following environment variables:
+
+- `MEDUSA_BACKEND_URL` - Used for server-side code (middleware)
+- `NEXT_PUBLIC_MEDUSA_BACKEND_URL` - Used for client-side code
+  
+The middleware will check for both variables, so you can set them to the same value for convenience.
+
 ### Install dependencies
 
 Use Yarn to install all dependencies.

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,7 +1,7 @@
 import { HttpTypes } from "@medusajs/types"
 import { NextRequest, NextResponse } from "next/server"
 
-const BACKEND_URL = process.env.MEDUSA_BACKEND_URL
+const BACKEND_URL = process.env.MEDUSA_BACKEND_URL || process.env.NEXT_PUBLIC_MEDUSA_BACKEND_URL
 const PUBLISHABLE_API_KEY = process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY
 const DEFAULT_REGION = process.env.NEXT_PUBLIC_DEFAULT_REGION || "us"
 
@@ -15,7 +15,7 @@ async function getRegionMap(cacheId: string) {
 
   if (!BACKEND_URL) {
     throw new Error(
-      "Middleware.ts: Error fetching regions. Did you set up regions in your Medusa Admin and define a MEDUSA_BACKEND_URL environment variable? Note that the variable is no longer named NEXT_PUBLIC_MEDUSA_BACKEND_URL."
+      "Middleware.ts: Error fetching regions. Please define either MEDUSA_BACKEND_URL or NEXT_PUBLIC_MEDUSA_BACKEND_URL environment variable pointing to your Medusa backend."
     )
   }
 
@@ -94,7 +94,7 @@ async function getCountryCode(
   } catch (error) {
     if (process.env.NODE_ENV === "development") {
       console.error(
-        "Middleware.ts: Error getting the country code. Did you set up regions in your Medusa Admin and define a MEDUSA_BACKEND_URL environment variable? Note that the variable is no longer named NEXT_PUBLIC_MEDUSA_BACKEND_URL."
+        "Middleware.ts: Error getting the country code. Please define either MEDUSA_BACKEND_URL or NEXT_PUBLIC_MEDUSA_BACKEND_URL environment variable pointing to your Medusa backend."
       )
     }
   }


### PR DESCRIPTION
## Description

This PR fixes issue #484 where the middleware only accepts `MEDUSA_BACKEND_URL` environment variable but not `NEXT_PUBLIC_MEDUSA_BACKEND_URL`, which causes confusion and errors when setting up the storefront.

## Changes

- Updated the middleware to check for both `MEDUSA_BACKEND_URL` and `NEXT_PUBLIC_MEDUSA_BACKEND_URL` environment variables
- Updated error messages to be more clear about the environment variables needed
- Updated the `.env.template` file to include both variables with explanations
- Updated README.md to document both environment variables

## Testing

Tested by running the application with only `NEXT_PUBLIC_MEDUSA_BACKEND_URL` defined, which now works correctly.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update (fixing inaccurate or missing information)

## Affected Components
- Middleware
- Documentation

## Related Issues
Fixes #484