### PR TITLE
Fix delete-button infinite spinner

### DIFF
--- a/src/modules/common/components/delete-button/index.tsx
+++ b/src/modules/common/components/delete-button/index.tsx
@@ -16,7 +16,7 @@ const DeleteButton = ({
 
   const handleDelete = async (id: string) => {
     setIsDeleting(true)
-    await deleteLineItem(id).catch((err) => {
+    await deleteLineItem(id).finally(() => {
       setIsDeleting(false)
     })
   }


### PR DESCRIPTION
Fix delete-button infinite spinner by replacing `.catch` that wasn't being used properly with `.finally` to stop the spinner