### PR TITLE
fix(checkout): add missing onChange to billing city input

### DIFF
--- a/src/modules/checkout/components/billing_address/index.tsx
+++ b/src/modules/checkout/components/billing_address/index.tsx
@@ -79,6 +79,7 @@ const BillingAddress = ({ cart }: { cart: HttpTypes.StoreCart | null }) => {
           name="billing_address.city"
           autoComplete="address-level2"
           value={formData["billing_address.city"]}
+          onChange={handleChange}
         />
         <CountrySelect
           name="billing_address.country_code"


### PR DESCRIPTION
Fixes #494

#### Summary
Adds the missing `onChange={handleChange}` to the **BillingAddress → City** input so the field is no longer read-only.

#### Changes introduced
```diff
-  value={formData["billing_address.city"]}
+  value={formData["billing_address.city"]}
+  onChange={handleChange}