### PR TITLE
Update products.ts

### DIFF
--- a/src/lib/data/products.ts
+++ b/src/lib/data/products.ts
@@ -7,6 +7,12 @@ import { SortOptions } from "@modules/store/components/refinement-list/sort-prod
 import { getAuthHeaders, getCacheOptions } from "./cookies"
 import { getRegion, retrieveRegion } from "./regions"
 
+
+type ExtendedQueryParams = HttpTypes.FindParams &
+  HttpTypes.StoreProductParams & {
+    collection_id?: string
+  }
+
 export const listProducts = async ({
   pageParam = 1,
   queryParams,
@@ -14,13 +20,13 @@ export const listProducts = async ({
   regionId,
 }: {
   pageParam?: number
-  queryParams?: HttpTypes.FindParams & HttpTypes.StoreProductParams
+  queryParams?: ExtendedQueryParams
   countryCode?: string
   regionId?: string
 }): Promise<{
   response: { products: HttpTypes.StoreProduct[]; count: number }
   nextPage: number | null
-  queryParams?: HttpTypes.FindParams & HttpTypes.StoreProductParams
+  queryParams?: ExtendedQueryParams
 }> => {
   if (!countryCode && !regionId) {
     throw new Error("Country code or region ID is required")
@@ -96,13 +102,13 @@ export const listProductsWithSort = async ({
   countryCode,
 }: {
   page?: number
-  queryParams?: HttpTypes.FindParams & HttpTypes.StoreProductParams
+  queryParams?: ExtendedQueryParams
   sortBy?: SortOptions
   countryCode: string
 }): Promise<{
   response: { products: HttpTypes.StoreProduct[]; count: number }
   nextPage: number | null
-  queryParams?: HttpTypes.FindParams & HttpTypes.StoreProductParams
+  queryParams?: ExtendedQueryParams
 }> => {
   const limit = queryParams?.limit || 12
 


### PR DESCRIPTION
The module src/modules/home/components/featured-products/product-rail/index.tsx depends on listProducts() from src/lib/data/products.ts.

Within product_rail, the query { collection_id: collection.id } is passed to listProducts(). However, collection_id is not currently defined in the type HttpTypes.FindParams & HttpTypes.StoreProductParams, which causes a TypeScript error:

"Object literal may only specify known properties, and 'collection_id' does not exist in type 'FindParams & StoreProductParams'.ts(2353)"

To resolve this, the queryParams type has been extended locally to include collection_id, which is a valid API field returned in HttpTypes.StoreProduct[].