### PR TITLE
fix: remove unused fields when listing shipping options

### DIFF
--- a/src/lib/data/fulfillment.ts
+++ b/src/lib/data/fulfillment.ts
@@ -20,8 +20,6 @@ export const listCartShippingMethods = async (cartId: string) => {
         method: "GET",
         query: {
           cart_id: cartId,
-          fields:
-            "+service_zone.fulfllment_set.type,*service_zone.fulfillment_set.location.address",
         },
         headers,
         next,


### PR DESCRIPTION
Those fields are simply unused (and there is also a typo in the word "fulfllment")