### PR TITLE
fix: handle when no region with country configured

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -147,6 +147,12 @@ export async function middleware(request: NextRequest) {
   if (!urlHasCountryCode && countryCode) {
     redirectUrl = `${request.nextUrl.origin}/${countryCode}${redirectPath}${queryString}`
     response = NextResponse.redirect(`${redirectUrl}`, 307)
+  } else if (!urlHasCountryCode && !countryCode) {
+    // Handle case where no valid country code exists (empty regions)
+    return new NextResponse(
+      "No valid regions configured. Please set up regions with countries in your Medusa Admin.",
+      { status: 500 }
+    )
   }
 
   return response


### PR DESCRIPTION
CLOSES #502 

Show error message if no region with country code could be found so the storefront does not enter infinite loop
<img width="2994" height="1882" alt="CleanShot 2025-09-19 at 13 14 43@2x" src="https://github.com/user-attachments/assets/54e51987-7915-482d-b0b9-e2e8ff965925" />
