### PR TITLE
Don't scroll on product action

### DIFF
--- a/src/modules/products/components/product-actions/index.tsx
+++ b/src/modules/products/components/product-actions/index.tsx
@@ -89,7 +89,7 @@ export default function ProductActions({
       params.delete("v_id")
     }
 
-    router.replace(pathname + "?" + params.toString())
+    router.replace(pathname + "?" + params.toString(), { scroll: false })
   }, [selectedVariant, isValidVariant])
 
   // check if the selected variant is in stock


### PR DESCRIPTION
Clicking a product action (e.g. changing product size or color) scrolls back up to the top of the page. On smaller screen sizes this causes the product actions to go off screen, forcing the user to scroll back down to further change options.

A very simple fix here is to just set `{scroll: false}` when navigating programmatically :)