### PR TITLE
Downgrade Next.js and React dependencies for compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,12 +22,12 @@
     "@stripe/react-stripe-js": "^5.3.0",
     "@stripe/stripe-js": "^8.2.0",
     "lodash": "^4.17.21",
-    "next": "^15.3.1",
+    "next": "14.2.5",
     "pg": "^8.11.3",
     "qs": "^6.12.1",
-    "react": "19.0.0-rc-66855b96-20241106",
+    "react": "18.3.1",
     "react-country-flag": "^3.1.0",
-    "react-dom": "19.0.0-rc-66855b96-20241106",
+    "react-dom": "18.3.1",
     "server-only": "^0.0.1",
     "tailwindcss-radix": "^2.8.0",
     "webpack": "^5"
@@ -46,19 +46,10 @@
     "autoprefixer": "^10.4.2",
     "babel-loader": "^8.2.3",
     "eslint": "8.10.0",
-    "eslint-config-next": "15.0.3",
+    "eslint-config-next": "14.2.5",
     "postcss": "^8.4.8",
     "prettier": "^2.8.8",
     "tailwindcss": "^3.0.23",
     "typescript": "^5.3.2"
-  },
-  "packageManager": "yarn@4.6.0",
-  "resolutions": {
-    "@types/react": "npm:types-react@19.0.0-rc.1",
-    "@types/react-dom": "npm:types-react-dom@19.0.0-rc.1"
-  },
-  "overrides": {
-    "react": "19.0.0-rc-66855b96-20241106",
-    "react-dom": "19.0.0-rc-66855b96-20241106"
   }
 }


### PR DESCRIPTION
This PR fixes the breaking issue caused by the upgrade to Next.js 15 and React 19 RC.

The current starter template depends on @medusajs/ui and Radix components that require React 18 and Next.js 14. The forced resolutions in package.json upgrade React and React-DOM to 19.0.0 RC, and Next.js resolves to 15.x. This produces a build-time failure:

<Html> should not be imported outside of pages/_document.

This error happens because Next.js 15 changes the Document handling and the starter template still relies on the Next 14 pages router (_document.tsx).

This PR:
- Pins Next.js to 14.2.5 (latest stable v14 compatible with pages router)
- Pins React and React-DOM to 18.3.1 (required by @medusajs/ui)
- Removes RC resolutions and overrides forcing React 19
- Restores compatibility with Medusa V2 starter template
- Removes peer dependency warnings and resolves the build error

After applying this change:
- `yarn build` works with zero errors
- The storefront runs correctly on Next 14
- @medusajs/ui and Radix components function as expected
- No `<Html>` import errors occur

Discussion and diagnostic details here:
[https://github.com/medusajs/nextjs-starter-medusa/discussions/544](https://github.com/medusajs/nextjs-starter-medusa/discussions/544)