### PR TITLE
fix: update Tailwind CSS content path to use dynamic Medusa UI path

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,7 @@
 const path = require("path")
 
+const medusaUiPath = path.dirname(require.resolve("@medusajs/ui"))
+
 module.exports = {
   darkMode: "class",
   presets: [require("@medusajs/ui-preset")],
@@ -8,7 +10,7 @@ module.exports = {
     "./src/pages/**/*.{js,ts,jsx,tsx}",
     "./src/components/**/*.{js,ts,jsx,tsx}",
     "./src/modules/**/*.{js,ts,jsx,tsx}",
-    "./node_modules/@medusajs/ui/dist/**/*.{js,jsx,ts,tsx}",
+    `${medusaUiPath}/**/*.{js,jsx,ts,tsx}`,
   ],
   theme: {
     extend: {


### PR DESCRIPTION
In pnpm monorepo setups, hard-coded paths like
`./node_modules/@medusajs/ui/dist/...` can break because pnpm uses a
content-addressable store and symlinks, not a flat node_modules layout.

This commit resolves the physical package location using Node’s module
resolution and constructs the Tailwind content glob dynamically.

This ensures compatibility across pnpm, npm, and yarn installs.
