### PR TITLE
adding next/babel presents to eslint parser options.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,8 @@
 module.exports = {
-  extends: ["next/core-web-vitals"]
-};
+  extends: ["next/core-web-vitals"],
+  parserOptions: {
+    babelOptions: {
+      presets: [require.resolve("next/babel")],
+    },
+  },
+}


### PR DESCRIPTION
## Problem 

VSCode was occasionally throwing this error in files within the storefront template:

```
Parsing error: Cannot find module 'next/babel'
Require stack:
- /medusa/storefront/node_modules/next/dist/compiled/babel/bundle.js
- /medusa/storefront/node_modules/next/dist/compiled/babel/eslint-parser.js
- /medusa/storefront/node_modules/eslint-config-next/parser.js
- /medusa/storefront/node_modules/@eslint/eslintrc/dist/eslintrc.cjs

Make sure that all the Babel plugins and presets you are using
are defined as dependencies or devDependencies in your package.json
file. It's possible that the missing plugin is loaded by a preset
you are using that forgot to add the plugin to its dependencies: you
can workaround this problem by explicitly adding the missing package
to your top-level package.json.
```

I asked Claude about what might cause this, and it suggestsed this fix. I no longer get parsing errors in VS Code after this change.

Hope this helps!
