### PR TITLE
Fix image retrieval for product variants

### DIFF
--- a/src/app/[countryCode]/(main)/products/[handle]/page.tsx
+++ b/src/app/[countryCode]/(main)/products/[handle]/page.tsx
@@ -61,7 +61,7 @@ function getImagesForVariant(
   }
 
   const variant = product.variants!.find((v) => v.id === selectedVariantId)
-  if (!variant || !variant.images.length) {
+  if (!variant || !variant.images?.length) {
     return product.images
   }
 
@@ -114,12 +114,12 @@ export default async function ProductPage(props: Props) {
     queryParams: { handle: params.handle },
   }).then(({ response }) => response.products[0])
 
-  const images = getImagesForVariant(pricedProduct, selectedVariantId)
-
   if (!pricedProduct) {
     notFound()
   }
-
+  
+  const images = getImagesForVariant(pricedProduct, selectedVariantId) ?? []
+  
   return (
     <ProductTemplate
       product={pricedProduct}


### PR DESCRIPTION
Ensure images fallback to an empty array if none are found for the selected variant.